### PR TITLE
feat: JSON schema validation for state files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check test test-e2e typecheck lint format fix all dev build clean
+.PHONY: check test test-e2e typecheck lint format fix all dev build clean validate
 .PHONY: check-header test-header check-verbose test-verbose
 
 # Full validation: check + test
@@ -71,3 +71,7 @@ db-push:
 # Clean build artifacts
 clean:
 	rm -rf .next dist node_modules/.cache
+
+# Validate state files against JSON schemas
+validate:
+	node scripts/validate-schemas.mjs

--- a/ralph/ralph-state.schema.json
+++ b/ralph/ralph-state.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "ralph-state.schema.json",
+  "title": "RalphState",
+  "description": "Runtime state machine for the ralph-to-ralph build loop",
+  "type": "object",
+  "required": ["phase", "iteration", "status"],
+  "additionalProperties": true,
+  "properties": {
+    "phase": {
+      "type": "string",
+      "enum": ["onboard", "inspect", "build", "qa", "complete", "failed"],
+      "description": "Current phase of the ralph pipeline"
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Current build/QA iteration count"
+    },
+    "status": {
+      "type": "object",
+      "description": "Structured status for current and past phases",
+      "required": ["current"],
+      "properties": {
+        "current": {
+          "type": "string",
+          "enum": ["idle", "running", "paused", "complete", "failed"],
+          "description": "Status of the currently active phase"
+        },
+        "onboard": {
+          "$ref": "#/definitions/phaseStatus"
+        },
+        "inspect": {
+          "$ref": "#/definitions/phaseStatus"
+        },
+        "build": {
+          "$ref": "#/definitions/phaseStatus"
+        },
+        "qa": {
+          "$ref": "#/definitions/phaseStatus"
+        }
+      }
+    },
+    "lastCheckpoint": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of last state save"
+    },
+    "budget": {
+      "type": "object",
+      "description": "Token/cost budget tracking for the session",
+      "properties": {
+        "maxIterations": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of build+QA cycles allowed"
+        },
+        "iterationsUsed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of iterations consumed so far"
+        },
+        "estimatedCostUsd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated API cost in USD so far"
+        },
+        "budgetCapUsd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Hard cap on API spend (stop if exceeded)"
+        },
+        "tokensIn": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total input tokens consumed"
+        },
+        "tokensOut": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total output tokens produced"
+        }
+      }
+    },
+    "currentFeature": {
+      "type": ["string", "null"],
+      "description": "ID of the PRD feature currently being built or tested"
+    },
+    "buildProgress": {
+      "type": "object",
+      "description": "Summary of build phase progress",
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "pending": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "qaProgress": {
+      "type": "object",
+      "description": "Summary of QA phase progress",
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "partial": { "type": "integer", "minimum": 0 },
+        "pending": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "phase": { "type": "string" },
+          "message": { "type": "string" },
+          "fatal": { "type": "boolean" }
+        },
+        "required": ["timestamp", "phase", "message"]
+      },
+      "description": "Error log across all phases"
+    }
+  },
+  "definitions": {
+    "phaseStatus": {
+      "type": "object",
+      "description": "Status record for a completed or in-progress phase",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pending", "running", "complete", "failed", "skipped"]
+        },
+        "startedAt": { "type": "string", "format": "date-time" },
+        "completedAt": { "type": "string", "format": "date-time" },
+        "iterations": { "type": "integer", "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/ralph/ralph-state.template.json
+++ b/ralph/ralph-state.template.json
@@ -1,0 +1,59 @@
+{
+  "phase": "onboard",
+  "iteration": 0,
+  "status": {
+    "current": "idle",
+    "onboard": {
+      "status": "pending",
+      "startedAt": null,
+      "completedAt": null,
+      "iterations": 0,
+      "notes": ""
+    },
+    "inspect": {
+      "status": "pending",
+      "startedAt": null,
+      "completedAt": null,
+      "iterations": 0,
+      "notes": ""
+    },
+    "build": {
+      "status": "pending",
+      "startedAt": null,
+      "completedAt": null,
+      "iterations": 0,
+      "notes": ""
+    },
+    "qa": {
+      "status": "pending",
+      "startedAt": null,
+      "completedAt": null,
+      "iterations": 0,
+      "notes": ""
+    }
+  },
+  "lastCheckpoint": null,
+  "budget": {
+    "maxIterations": 999,
+    "iterationsUsed": 0,
+    "estimatedCostUsd": 0,
+    "budgetCapUsd": null,
+    "tokensIn": 0,
+    "tokensOut": 0
+  },
+  "currentFeature": null,
+  "buildProgress": {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "pending": 0
+  },
+  "qaProgress": {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "partial": 0,
+    "pending": 0
+  },
+  "errors": []
+}

--- a/schemas/prd-item.schema.json
+++ b/schemas/prd-item.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "prd-item.schema.json",
+  "title": "PrdItem",
+  "description": "A single feature item in the Product Requirements Document",
+  "type": "object",
+  "required": ["id", "name", "description", "priority", "category"],
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+      "description": "Unique kebab-case identifier (e.g. 'auth-001', 'feature-dashboard')"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short human-readable feature name"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Detailed description of what this feature does"
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["P0", "P1", "P2", "P3", "P4", "P5", "P6"],
+      "description": "Feature priority: P0 = critical blocker, P6 = nice-to-have"
+    },
+    "category": {
+      "type": "string",
+      "description": "Feature category (e.g. 'auth', 'dashboard', 'api', 'ui', 'infra')"
+    },
+    "build_pass": {
+      "type": "boolean",
+      "default": false,
+      "description": "Set to true by build agent when feature is implemented and tests pass"
+    },
+    "qa_pass": {
+      "type": "boolean",
+      "default": false,
+      "description": "Set to true by QA agent after successful manual/automated verification"
+    },
+    "dependencies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of feature IDs that must be build_pass before this feature can be built",
+      "default": []
+    },
+    "dependent_on": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Alias for dependencies — feature IDs this feature depends on",
+      "default": []
+    },
+    "steps": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Acceptance criteria / test steps for verifying the feature"
+    },
+    "behavior": {
+      "type": "string",
+      "description": "Description of expected behavior (used by QA for comparison)"
+    },
+    "pages": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "App routes or pages this feature affects"
+    }
+  }
+}

--- a/schemas/qa-report-entry.schema.json
+++ b/schemas/qa-report-entry.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "qa-report-entry.schema.json",
+  "title": "QaReportEntry",
+  "description": "A single QA test result entry appended to qa-report.json",
+  "type": "object",
+  "required": ["feature_id", "attempt", "status"],
+  "additionalProperties": true,
+  "properties": {
+    "feature_id": {
+      "type": "string",
+      "description": "ID of the PRD feature being tested (must match prd.json id)"
+    },
+    "attempt": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "QA attempt number (increments on each retry)"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail", "partial"],
+      "description": "Overall test outcome"
+    },
+    "errors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of error messages encountered during testing"
+    },
+    "screenshots": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string", "description": "Relative path to screenshot file" },
+          "label": { "type": "string", "description": "Description of what the screenshot shows" }
+        },
+        "required": ["path"]
+      },
+      "description": "Screenshots captured during QA"
+    },
+    "bugs_found": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "description"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "major", "minor", "cosmetic"],
+            "description": "Bug severity level"
+          },
+          "description": {
+            "type": "string",
+            "description": "What is broken"
+          },
+          "expected": {
+            "type": "string",
+            "description": "Expected behavior"
+          },
+          "actual": {
+            "type": "string",
+            "description": "Actual observed behavior"
+          },
+          "reproduction": {
+            "type": "string",
+            "description": "Steps to reproduce"
+          },
+          "file": {
+            "type": "string",
+            "description": "Source file where bug was found"
+          },
+          "steps_to_reproduce": {
+            "type": "string",
+            "description": "Alias for reproduction"
+          }
+        }
+      },
+      "description": "Bugs found during this QA attempt"
+    },
+    "tested_steps": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of acceptance criteria steps that were tested and their results"
+    },
+    "fix_description": {
+      "type": "string",
+      "description": "Brief description of fix attempted (or 'no fix needed' if passed)"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when this QA run completed"
+    }
+  }
+}

--- a/schemas/ralph-config.schema.json
+++ b/schemas/ralph-config.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "ralph-config.schema.json",
+  "title": "RalphConfig",
+  "description": "Single source of truth for a ralph-to-ralph clone project",
+  "type": "object",
+  "required": ["targetUrl", "targetName", "cloudProvider", "framework", "database"],
+  "additionalProperties": true,
+  "properties": {
+    "targetUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the product being cloned"
+    },
+    "targetName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the target product"
+    },
+    "cloneName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name for the clone project"
+    },
+    "cloudProvider": {
+      "type": "string",
+      "enum": ["aws", "gcp", "azure", "vercel", "custom"],
+      "description": "Cloud deployment provider"
+    },
+    "framework": {
+      "type": "string",
+      "enum": ["nextjs", "remix", "vite", "express", "custom"],
+      "description": "Frontend/fullstack framework"
+    },
+    "database": {
+      "type": "string",
+      "enum": ["postgres", "mysql", "sqlite", "mongodb", "custom"],
+      "description": "Database technology"
+    },
+    "authMode": {
+      "type": "string",
+      "enum": ["api-key", "better-auth"],
+      "default": "api-key",
+      "description": "Authentication mode: api-key for personal use, better-auth for multi-user"
+    },
+    "stackProfile": {
+      "type": "string",
+      "description": "Named stack profile used during onboarding (e.g. 'nextjs-postgres', 'remix-sqlite')"
+    },
+    "services": {
+      "type": "object",
+      "description": "Cloud services required by the clone",
+      "additionalProperties": true,
+      "properties": {
+        "storage": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "provider": { "type": "string" },
+            "bucket": { "type": "string" }
+          }
+        },
+        "email": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "provider": { "type": "string" },
+            "fromAddress": { "type": "string" }
+          }
+        },
+        "queue": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "provider": { "type": "string" }
+          }
+        },
+        "search": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "provider": { "type": "string" }
+          }
+        },
+        "cache": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "provider": { "type": "string" }
+          }
+        }
+      }
+    },
+    "browserAgent": {
+      "type": "string",
+      "enum": ["ever", "playwright", "stagehand", "custom"],
+      "default": "ever",
+      "description": "Browser automation agent for QA and inspection phases"
+    },
+    "skipDeployment": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, skip cloud deployment setup — only provision local dev dependencies"
+    },
+    "testAccount": {
+      "type": "object",
+      "description": "Test account credentials for QA (stored by reference to .env vars)",
+      "properties": {
+        "email": { "type": "string", "format": "email" },
+        "provider": { "type": "string", "enum": ["google", "github", "email"] }
+      }
+    },
+    "setup": {
+      "type": "object",
+      "description": "System dependency verification results written by onboard.sh",
+      "properties": {
+        "verified": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "pending": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "checks": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "command": { "type": "string" },
+              "envVar": { "type": "string" },
+              "status": { "type": "string", "enum": ["pass", "fail", "skip"] },
+              "detail": { "type": "string" },
+              "error": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * validate-schemas.mjs
+ * Validates ralph-to-ralph state files against their JSON schemas.
+ * Run via: node scripts/validate-schemas.mjs
+ * Or:      make validate
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// ── Minimal JSON Schema draft-07 validator ──────────────────────────────────
+// Supports: type, required, enum, properties, additionalProperties,
+//           items, minimum, minLength, pattern, format (uri/email — syntax only)
+
+function validateSchema(data, schema, path = "$") {
+  const errors = [];
+
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const jsType = data === null ? "null" : Array.isArray(data) ? "array" : typeof data;
+    const typeMap = { integer: "number" };
+    const matches = types.some((t) => {
+      if (t === "integer") return Number.isInteger(data);
+      return jsType === (typeMap[t] ?? t);
+    });
+    if (!matches) {
+      errors.push(`${path}: expected type ${types.join("|")}, got ${jsType}`);
+      return errors; // can't validate further if wrong type
+    }
+  }
+
+  if (schema.enum !== undefined) {
+    if (!schema.enum.includes(data)) {
+      errors.push(`${path}: value ${JSON.stringify(data)} not in enum [${schema.enum.map((v) => JSON.stringify(v)).join(", ")}]`);
+    }
+  }
+
+  if (schema.minLength !== undefined && typeof data === "string") {
+    if (data.length < schema.minLength) {
+      errors.push(`${path}: string length ${data.length} < minLength ${schema.minLength}`);
+    }
+  }
+
+  if (schema.minimum !== undefined && typeof data === "number") {
+    if (data < schema.minimum) {
+      errors.push(`${path}: value ${data} < minimum ${schema.minimum}`);
+    }
+  }
+
+  if (schema.pattern !== undefined && typeof data === "string") {
+    const re = new RegExp(schema.pattern);
+    if (!re.test(data)) {
+      errors.push(`${path}: string does not match pattern ${schema.pattern}`);
+    }
+  }
+
+  if (schema.format && typeof data === "string") {
+    if (schema.format === "uri") {
+      try { new URL(data); } catch {
+        errors.push(`${path}: invalid URI format: ${data}`);
+      }
+    }
+    if (schema.format === "email") {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data)) {
+        errors.push(`${path}: invalid email format: ${data}`);
+      }
+    }
+    if (schema.format === "date-time" && data !== null) {
+      if (Number.isNaN(Date.parse(data))) {
+        errors.push(`${path}: invalid date-time format: ${data}`);
+      }
+    }
+  }
+
+  if (schema.required && typeof data === "object" && data !== null && !Array.isArray(data)) {
+    for (const key of schema.required) {
+      if (!(key in data)) {
+        errors.push(`${path}: missing required property "${key}"`);
+      }
+    }
+  }
+
+  if (schema.properties && typeof data === "object" && data !== null && !Array.isArray(data)) {
+    for (const [key, subSchema] of Object.entries(schema.properties)) {
+      if (key in data) {
+        errors.push(...validateSchema(data[key], subSchema, `${path}.${key}`));
+      }
+    }
+  }
+
+  if (schema.items && Array.isArray(data)) {
+    for (let i = 0; i < data.length; i++) {
+      errors.push(...validateSchema(data[i], schema.items, `${path}[${i}]`));
+    }
+  }
+
+  return errors;
+}
+
+// ── Load schema helper ──────────────────────────────────────────────────────
+
+function loadSchema(relPath) {
+  const full = resolve(ROOT, relPath);
+  return JSON.parse(readFileSync(full, "utf8"));
+}
+
+function loadData(relPath) {
+  const full = resolve(ROOT, relPath);
+  if (!existsSync(full)) return null;
+  return JSON.parse(readFileSync(full, "utf8"));
+}
+
+// ── Validation targets ──────────────────────────────────────────────────────
+
+const targets = [
+  {
+    label: "ralph-config.json",
+    dataPath: "ralph-config.json",
+    schemaPath: "schemas/ralph-config.schema.json",
+    required: false, // may not exist yet (pre-onboard)
+  },
+  {
+    label: "prd.json (array of items)",
+    dataPath: "prd.json",
+    schemaPath: "schemas/prd-item.schema.json",
+    isArray: true,
+    required: false,
+  },
+  {
+    label: "qa-report.json (array of entries)",
+    dataPath: "qa-report.json",
+    schemaPath: "schemas/qa-report-entry.schema.json",
+    isArray: true,
+    required: false,
+  },
+  {
+    label: "ralph/ralph-state.json (if present)",
+    dataPath: "ralph/ralph-state.json",
+    schemaPath: "ralph/ralph-state.schema.json",
+    required: false,
+  },
+];
+
+// ── Run validations ─────────────────────────────────────────────────────────
+
+let totalErrors = 0;
+let totalChecked = 0;
+let totalSkipped = 0;
+
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const RESET = "\x1b[0m";
+
+console.log("\n=== ralph-to-ralph schema validation ===\n");
+
+for (const target of targets) {
+  const data = loadData(target.dataPath);
+
+  if (data === null) {
+    if (target.required) {
+      console.log(`${RED}MISSING${RESET}  ${target.label} — file not found (required)`);
+      totalErrors++;
+    } else {
+      console.log(`${YELLOW}SKIP${RESET}     ${target.label} — file not found (optional)`);
+      totalSkipped++;
+    }
+    continue;
+  }
+
+  const schema = loadSchema(target.schemaPath);
+  let errors = [];
+
+  if (target.isArray) {
+    if (!Array.isArray(data)) {
+      errors.push("$: expected array at root");
+    } else {
+      for (let i = 0; i < data.length; i++) {
+        errors.push(...validateSchema(data[i], schema, `$[${i}]`));
+      }
+    }
+  } else {
+    errors = validateSchema(data, schema, "$");
+  }
+
+  totalChecked++;
+
+  if (errors.length === 0) {
+    const count = target.isArray ? ` (${data.length} items)` : "";
+    console.log(`${GREEN}PASS${RESET}     ${target.label}${count}`);
+  } else {
+    console.log(`${RED}FAIL${RESET}     ${target.label} — ${errors.length} error(s):`);
+    for (const err of errors) {
+      console.log(`           ${RED}✗${RESET} ${err}`);
+    }
+    totalErrors += errors.length;
+  }
+}
+
+console.log(`\n─────────────────────────────────────────`);
+console.log(`Checked: ${totalChecked}  Skipped: ${totalSkipped}  Errors: ${totalErrors}`);
+
+if (totalErrors > 0) {
+  console.log(`\n${RED}Validation failed.${RESET} Fix the errors above.\n`);
+  process.exit(1);
+} else {
+  console.log(`\n${GREEN}All validations passed.${RESET}\n`);
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary
- JSON schemas for ralph-config, PRD items, QA report entries, and ralph-state machine
- Zero-dependency Node.js validation script (`scripts/validate-schemas.mjs`)
- `make validate` target to check all state files before each phase
- State machine template (`ralph-state.template.json`) for explicit phase tracking

## Test plan
- [ ] Run `make validate` on clean repo — should pass (skips optional files)
- [ ] Create invalid ralph-config.json and verify errors are reported
- [ ] Verify schemas match actual file formats used by inspect/build/QA phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)