### PR TITLE
feat: prefer uv run python3 when available in ralph scripts

### DIFF
--- a/ralph/build-ralph.sh
+++ b/ralph/build-ralph.sh
@@ -13,6 +13,13 @@ if ! command -v timeout &>/dev/null; then
   fi
 fi
 
+# Resolve Python: prefer `uv run python3` if uv is available, fall back to bare python3
+if command -v uv &>/dev/null; then
+  PY="uv run python3"
+else
+  PY="python3"
+fi
+
 ITERATIONS="${1:-999}"
 
 [ -f ralph-config.json ] || { echo "ERROR: ralph-config.json not found. Run ./ralph/onboard.sh first."; exit 1; }
@@ -35,15 +42,15 @@ echo ""
 touch build-progress.txt
 
 count_passes() {
-  python3 -c "import json; d=json.load(open('prd.json')); print(sum(1 for x in d if x.get('build_pass', False)))" 2>/dev/null || echo "0"
+  $PY -c "import json; d=json.load(open('prd.json')); print(sum(1 for x in d if x.get('build_pass', False)))" 2>/dev/null || echo "0"
 }
 total_tasks() {
-  python3 -c "import json; print(len(json.load(open('prd.json'))))" 2>/dev/null || echo "0"
+  $PY -c "import json; print(len(json.load(open('prd.json'))))" 2>/dev/null || echo "0"
 }
 
 # Get QA failure context for the next feature to build (if any)
 get_qa_context() {
-  python3 -c "
+  $PY -c "
 import json, sys
 
 # Find the first feature where build_pass is false

--- a/ralph/inspect-ralph.sh
+++ b/ralph/inspect-ralph.sh
@@ -7,8 +7,15 @@ cd "$(dirname "$0")/.."
 TARGET_URL="${1:?Usage: $0 <target-url> [iterations]}"
 ITERATIONS="${2:-999}"
 
+# Resolve Python: prefer `uv run python3` if uv is available, fall back to bare python3
+if command -v uv &>/dev/null; then
+  PY="uv run python3"
+else
+  PY="python3"
+fi
+
 [ -f ralph-config.json ] || { echo "ERROR: ralph-config.json not found. Run ./ralph/onboard.sh first."; exit 1; }
-BROWSER_AGENT=$(python3 -c "import json; print(json.load(open('ralph-config.json')).get('browserAgent', 'ever'))" 2>/dev/null || echo "ever")
+BROWSER_AGENT=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('browserAgent', 'ever'))" 2>/dev/null || echo "ever")
 
 echo "=== RALPH-TO-RALPH: Phase 1 (Inspect) ==="
 echo "Target: $TARGET_URL"

--- a/ralph/qa-ralph.sh
+++ b/ralph/qa-ralph.sh
@@ -8,6 +8,13 @@ TARGET_URL="${1:-}"
 ITERATIONS="${2:-999}"
 MAX_RETRIES=5
 
+# Resolve Python: prefer `uv run python3` if uv is available, fall back to bare python3
+if command -v uv &>/dev/null; then
+  PY="uv run python3"
+else
+  PY="python3"
+fi
+
 # Adaptive timeout per feature category (seconds)
 get_qa_timeout() {
   local category="$1"
@@ -24,7 +31,7 @@ get_qa_timeout() {
 }
 
 [ -f ralph-config.json ] || { echo "ERROR: ralph-config.json not found. Run ./ralph/onboard.sh first."; exit 1; }
-BROWSER_AGENT=$(python3 -c "import json; print(json.load(open('ralph-config.json')).get('browserAgent', 'ever'))" 2>/dev/null || echo "ever")
+BROWSER_AGENT=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('browserAgent', 'ever'))" 2>/dev/null || echo "ever")
 
 if [ ! -f "prd.json" ]; then
   echo "Error: prd.json not found. Run build-ralph.sh first."
@@ -75,7 +82,7 @@ fi
 
 # ── Helper: get next feature where qa_pass is not true ──
 get_next_feature_with_deps() {
-  python3 -c "
+  $PY -c "
 import json, sys
 from collections import Counter
 
@@ -126,7 +133,7 @@ print(json.dumps(result))
 # ── Helper: get current attempt number for a feature ──
 get_attempt_number() {
   local feature_id="$1"
-  python3 -c "
+  $PY -c "
 import json
 try:
     report = json.load(open('qa-report.json'))
@@ -139,7 +146,7 @@ except: print(1)
 # ── Helper: get full attempt history for a feature ──
 get_feature_history() {
   local feature_id="$1"
-  python3 -c "
+  $PY -c "
 import json
 try:
     report = json.load(open('qa-report.json'))
@@ -164,12 +171,12 @@ except Exception as e:
 }
 
 total_features() {
-  python3 -c "import json; print(len(json.load(open('prd.json'))))" 2>/dev/null || echo "0"
+  $PY -c "import json; print(len(json.load(open('prd.json'))))" 2>/dev/null || echo "0"
 }
 
 # Count features that are done (qa_pass: true or exhausted retries)
 tested_count() {
-  python3 -c "
+  $PY -c "
 import json
 from collections import Counter
 try:
@@ -196,9 +203,9 @@ for ((i=1; i<=$ITERATIONS; i++)); do
     break
   fi
 
-  FEATURE_ID=$(echo "$FEATURE_BUNDLE" | python3 -c "import json,sys; print(json.load(sys.stdin)['main']['id'])")
-  FEATURE_CAT=$(echo "$FEATURE_BUNDLE" | python3 -c "import json,sys; print(json.load(sys.stdin)['main'].get('category',''))")
-  DEP_COUNT=$(echo "$FEATURE_BUNDLE" | python3 -c "import json,sys; print(len(json.load(sys.stdin)['dependencies']))")
+  FEATURE_ID=$(echo "$FEATURE_BUNDLE" | $PY -c "import json,sys; print(json.load(sys.stdin)['main']['id'])")
+  FEATURE_CAT=$(echo "$FEATURE_BUNDLE" | $PY -c "import json,sys; print(json.load(sys.stdin)['main'].get('category',''))")
+  DEP_COUNT=$(echo "$FEATURE_BUNDLE" | $PY -c "import json,sys; print(len(json.load(sys.stdin)['dependencies']))")
   ATTEMPT=$(get_attempt_number "$FEATURE_ID")
   HISTORY=$(get_feature_history "$FEATURE_ID")
 
@@ -207,7 +214,7 @@ for ((i=1; i<=$ITERATIONS; i++)); do
 
   echo "$FEATURE_BUNDLE" > .current-feature.json
 
-  QA_HINTS=$(python3 -c "
+  QA_HINTS=$($PY -c "
 import json
 try:
     hints = json.load(open('qa-hints.json'))
@@ -228,10 +235,10 @@ except:
 "$(cat ralph/qa-prompt.md)
 
 == FEATURE TO TEST ==
-$(python3 -c "import json; d=json.load(open('.current-feature.json')); print(json.dumps(d['main'], indent=2))")
+$($PY -c "import json; d=json.load(open('.current-feature.json')); print(json.dumps(d['main'], indent=2))")
 
 == RELATED FEATURES (dependencies for context) ==
-$(python3 -c "
+$($PY -c "
 import json
 d=json.load(open('.current-feature.json'))
 deps = d.get('dependencies', [])
@@ -278,7 +285,7 @@ Then:
 
   # No promise = crash or context overflow. Record as partial and move on.
   echo "WARNING: No promise from Codex for $FEATURE_ID (attempt $ATTEMPT). Recording as partial..."
-  python3 -c "
+  $PY -c "
 import json
 report = json.load(open('qa-report.json'))
 report.append({

--- a/ralph/ralph-watchdog.sh
+++ b/ralph/ralph-watchdog.sh
@@ -169,7 +169,7 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
 
   while [ "$(qa_complete)" != "true" ] && [ "$qa_restarts" -lt "$MAX_QA_RESTARTS" ]; do
     qa_restarts=$((qa_restarts + 1))
-    QA_SO_FAR=$(python3 -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
+    QA_SO_FAR=$($PY -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
     check_time_budget
     log "Phase 3: Running QA... $QA_SO_FAR/$(total_tasks) passed (attempt $qa_restarts/$MAX_QA_RESTARTS)"
     ./ralph/qa-ralph.sh "$TARGET_URL" || true

--- a/scripts/generate-demo-keys.sh
+++ b/scripts/generate-demo-keys.sh
@@ -7,6 +7,13 @@ COUNT="${1:-20}"
 API_URL="${2:-http://127.0.0.1:3002}"
 MASTER_KEY="${DASHBOARD_KEY:-re_dev_token_123}"
 
+# Resolve Python: prefer `uv run python3` if uv is available, fall back to bare python3
+if command -v uv &>/dev/null; then
+  PY="uv run python3"
+else
+  PY="python3"
+fi
+
 echo "=== Generating $COUNT demo API keys ==="
 echo "API: $API_URL"
 echo ""
@@ -22,7 +29,7 @@ for i in $(seq 1 $COUNT); do
     }).then(r=>r.json()).then(d=>console.log(JSON.stringify(d))).catch(e=>console.error(e))
   " 2>&1)
 
-  TOKEN=$(echo "$RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('token','ERROR'))" 2>/dev/null || echo "ERROR")
+  TOKEN=$(echo "$RESULT" | $PY -c "import json,sys; d=json.load(sys.stdin); print(d.get('token','ERROR'))" 2>/dev/null || echo "ERROR")
 
   if [ "$TOKEN" != "ERROR" ]; then
     echo "$TOKEN,$NAME,full_access"


### PR DESCRIPTION
## Summary
- Adds a `PY` resolver at the top of each ralph script: uses `uv run python3` when `uv` is installed, falls back to bare `python3` otherwise.
- Applies the pattern to `build-ralph.sh`, `inspect-ralph.sh`, `qa-ralph.sh`, and `scripts/generate-demo-keys.sh`.
- Fixes one leftover bare `python3` call in `ralph-watchdog.sh` (the `PY` block already existed there).
- `onboard.sh` was already using this pattern and is unchanged — the `command -v python3` existence check in onboard remains intentional.

## Why
Users with `uv`-managed Python environments can now run the ralph loop without relying on a global `python3` on PATH. Matches the pattern used in the `namuh-linear` test clone.

## Test plan
- [x] `bash -n` syntax check passes on all 5 modified scripts
- [x] Run `./ralph/ralph-watchdog.sh` end-to-end on a machine with `uv` installed
- [x] Run `./ralph/ralph-watchdog.sh` end-to-end on a machine without `uv` (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)