### PR TITLE
Add a watchdog verification gate before QA

### DIFF
--- a/ralph/ralph-watchdog.sh
+++ b/ralph/ralph-watchdog.sh
@@ -43,6 +43,12 @@ check_time_budget() {
   fi
 }
 
+# Verification gate commands. Keep them overridable for tests and stack-specific tuning.
+VERIFY_CHECK_CMD="${VERIFY_CHECK_CMD:-make check}"
+VERIFY_TEST_CMD="${VERIFY_TEST_CMD:-make test}"
+VERIFY_BUILD_CMD="${VERIFY_BUILD_CMD:-make build}"
+VERIFY_DOCKER_CMD="${VERIFY_DOCKER_CMD:-docker build -t ralph-watchdog-verify .}"
+
 # Lock file
 if [ -f "$LOCKFILE" ]; then
   PID=$(cat "$LOCKFILE" 2>/dev/null)
@@ -320,6 +326,54 @@ inspect_done() {
   [ -f ".inspect-complete" ]
 }
 
+run_verification_command() {
+  local label="$1"
+  local command="$2"
+
+  log "Phase 2: Verification gate running: $label"
+  sh -c "$command" >>"$LOG_FILE" 2>&1
+}
+
+verify_build_integrity() {
+  run_verification_command "check" "$VERIFY_CHECK_CMD" || return 1
+  run_verification_command "test" "$VERIFY_TEST_CMD" || return 1
+  run_verification_command "build" "$VERIFY_BUILD_CMD" || return 1
+
+  if [ -f "Dockerfile" ]; then
+    run_verification_command "docker" "$VERIFY_DOCKER_CMD" || return 1
+  fi
+
+  return 0
+}
+
+reset_verification_flags() {
+  local reset_summary
+  reset_summary=$($PY - <<'PY'
+import json
+
+with open("prd.json") as f:
+    prd = json.load(f)
+
+build_reset = 0
+qa_reset = 0
+
+for item in prd:
+    if item.get("build_pass", False):
+        item["build_pass"] = False
+        build_reset += 1
+    if item.get("qa_pass", False):
+        item["qa_pass"] = False
+        qa_reset += 1
+
+with open("prd.json", "w") as f:
+    json.dump(prd, f, indent=2)
+
+print(f"build={build_reset} qa={qa_reset}")
+PY
+  )
+  log "Phase 2: Reset verification flags ($reset_summary)"
+}
+
 cron_backup() {
   git add -A 2>/dev/null
   git commit -m "watchdog backup $(date '+%H:%M') — $(count_passes)/$(total_tasks) passes" 2>/dev/null || true
@@ -341,7 +395,7 @@ init_failure_log
 
 # ─── PHASE 1: Inspect ───
 
-MAX_INSPECT_RESTARTS=5
+MAX_INSPECT_RESTARTS="${MAX_INSPECT_RESTARTS:-5}"
 inspect_restarts=0
 
 while ! inspect_done; do
@@ -384,7 +438,7 @@ done
 
 # ─── PHASE 2 + 3: Build → QA → Fix loop ───
 
-MAX_CYCLES=5
+MAX_CYCLES="${MAX_CYCLES:-5}"
 for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
   log ""
   log "===== CYCLE $cycle/$MAX_CYCLES ====="
@@ -392,7 +446,7 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
   check_budget
 
   # ─── PHASE 2: Build ───
-  MAX_BUILD_RESTARTS=10
+  MAX_BUILD_RESTARTS="${MAX_BUILD_RESTARTS:-10}"
   build_restarts=0
 
   while ! all_passed; do
@@ -419,7 +473,7 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
     cron_backup
 
     if all_passed; then
-      log "Phase 2: All $(total_tasks) features pass!"
+      log "Phase 2: All $(total_tasks) features report build_pass."
       break
     fi
 
@@ -438,8 +492,22 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
     sleep 5
   done
 
+  if ! all_passed; then
+    log "Phase 2: Build incomplete after $build_restarts attempts. Skipping QA and restarting build cycle."
+    continue
+  fi
+
+  if ! verify_build_integrity; then
+    log "Phase 2: Verification gate failed. Resetting build and QA flags before retrying build."
+    reset_verification_flags
+    cron_backup
+    continue
+  fi
+
+  log "Phase 2: Verification gate passed. Proceeding to QA."
+
   # ─── PHASE 3: QA ───
-  MAX_QA_RESTARTS=10
+  MAX_QA_RESTARTS="${MAX_QA_RESTARTS:-10}"
   qa_restarts=0
 
   while [ "$(qa_complete)" != "true" ] && [ "$qa_restarts" -lt "$MAX_QA_RESTARTS" ]; do

--- a/tests/ralph-watchdog-verification.sh
+++ b/tests/ralph-watchdog-verification.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# ABOUTME: Regression test for the watchdog's independent build verification gate.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_file_exists() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "expected file to exist: $path" >&2
+    exit 1
+  fi
+}
+
+assert_file_not_exists() {
+  local path="$1"
+  if [ -f "$path" ]; then
+    echo "expected file to be absent: $path" >&2
+    exit 1
+  fi
+}
+
+assert_json_field_equals() {
+  local path="$1"
+  local field="$2"
+  local expected="$3"
+
+  local actual
+  actual="$(python3 - "$path" "$field" <<'PY'
+import json, sys
+path, field = sys.argv[1], sys.argv[2]
+value = json.load(open(path))[0]
+for part in field.split("."):
+    value = value[part]
+print(str(value).lower() if isinstance(value, bool) else value)
+PY
+)"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "expected $field in $path to be $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$TMP_DIR/ralph" "$TMP_DIR/bin"
+cp "$REPO_ROOT/ralph/ralph-watchdog.sh" "$TMP_DIR/ralph/ralph-watchdog.sh"
+chmod +x "$TMP_DIR/ralph/ralph-watchdog.sh"
+
+cat > "$TMP_DIR/prd.json" <<'EOF'
+[
+  {
+    "id": "feature-1",
+    "description": "Stub feature",
+    "build_pass": true,
+    "qa_pass": false
+  }
+]
+EOF
+
+cat > "$TMP_DIR/ralph-config.json" <<'EOF'
+{
+  "browserAgent": "custom",
+  "maxBudget": 0
+}
+EOF
+
+touch "$TMP_DIR/.inspect-complete"
+
+cat > "$TMP_DIR/ralph/inspect-ralph.sh" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat > "$TMP_DIR/ralph/build-ralph.sh" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat > "$TMP_DIR/ralph/qa-ralph.sh" <<'EOF'
+#!/bin/bash
+cd "$(dirname "$0")/.."
+touch qa-ran
+python3 - <<'PY'
+import json
+with open("prd.json") as f:
+    data = json.load(f)
+data[0]["qa_pass"] = True
+with open("prd.json", "w") as f:
+    json.dump(data, f, indent=2)
+PY
+exit 0
+EOF
+
+chmod +x "$TMP_DIR/ralph/inspect-ralph.sh" "$TMP_DIR/ralph/build-ralph.sh" "$TMP_DIR/ralph/qa-ralph.sh"
+
+cat > "$TMP_DIR/bin/make" <<'EOF'
+#!/bin/bash
+cd "$(dirname "$0")/.."
+touch make-called
+if [ "${1:-}" = "check" ]; then
+  exit 1
+fi
+exit 0
+EOF
+
+chmod +x "$TMP_DIR/bin/make"
+
+(
+  cd "$TMP_DIR"
+  PATH="$TMP_DIR/bin:/usr/bin:/bin:/usr/sbin:/sbin" MAX_CYCLES=1 ./ralph/ralph-watchdog.sh "https://example.com" >/dev/null 2>&1 || true
+)
+
+assert_file_exists "$TMP_DIR/make-called"
+assert_file_not_exists "$TMP_DIR/qa-ran"
+assert_json_field_equals "$TMP_DIR/prd.json" "build_pass" "false"
+assert_json_field_equals "$TMP_DIR/prd.json" "qa_pass" "false"
+
+echo "watchdog verification gate test passed"


### PR DESCRIPTION
## Summary
- add a Phase 2 verification gate in `ralph-watchdog.sh` so QA only starts after the workspace passes the repo contract commands
- reset stale `build_pass` / `qa_pass` flags when whole-workspace verification fails, forcing the build loop to re-earn them
- add a temp-workspace shell regression test that proves the watchdog no longer enters QA when verification fails

Refs #17

## Changes
- **watchdog**: add env-overridable verification commands, bounded retry env vars for testing, and explicit build-incomplete / verification-failed handling
- **tests**: add `tests/ralph-watchdog-verification.sh` to exercise the stale-pass failure mode without requiring onboarding-generated app files

## How to Test
- [ ] `bash tests/ralph-watchdog-verification.sh`
- [ ] `bash -n ralph/ralph-watchdog.sh tests/ralph-watchdog-verification.sh`
- [ ] In an onboarded workspace, force `make check` to fail and confirm the watchdog does not enter QA and clears stale pass flags

## Notes
- This PR is draft because the local regression path is verified, but the full onboarded workspace path with real `make` targets and optional `Dockerfile` still needs a live run.
- The reset behavior is intentionally coarse: after a whole-workspace verification failure, the watchdog clears stored pass flags rather than trying to preserve partially trusted state.