### PR TITLE
feat: port local dev compose and integration test targets

### DIFF
--- a/.claude/skills/ralph-to-ralph-onboard/templates/typescript-nextjs/makefile-targets.mk
+++ b/.claude/skills/ralph-to-ralph-onboard/templates/typescript-nextjs/makefile-targets.mk
@@ -39,3 +39,18 @@ db-push:
 
 clean:
 	rm -rf .next dist node_modules/.cache
+
+down:
+	docker compose -f docker-compose.dev.yml down
+
+logs:
+	docker compose -f docker-compose.dev.yml logs -f
+
+# Integration tests (real DB, not mocks)
+test-integration:
+	@. ./hack/run_silent.sh && \
+	run_silent_with_test_count "Integration Tests passed" "npx vitest run --config vitest.config.ts --reporter=verbose tests/integration" "vitest"
+
+# Drizzle Studio
+db-studio:
+	npx drizzle-kit studio --config drizzle.config.ts

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ralph
+      POSTGRES_PASSWORD: ralph
+      POSTGRES_DB: ralph_dev
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ralph -d ralph_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+    environment:
+      MP_MAX_MESSAGES: 500
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+
+volumes:
+  postgres_data:

--- a/tests/factories/README.md
+++ b/tests/factories/README.md
@@ -1,0 +1,71 @@
+# Test Factories
+
+Factories create realistic test data with sensible defaults, reducing boilerplate in tests.
+
+## Pattern
+
+Each factory is a function that accepts partial overrides and returns a complete object.
+Integration tests use factories with the real database; unit tests use them as plain objects.
+
+## Example Template
+
+```typescript
+// tests/factories/user.factory.ts
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+let counter = 0;
+
+function uniqueEmail() {
+  return `user-${++counter}-${Date.now()}@example.com`;
+}
+
+export function buildUser(overrides: Partial<typeof users.$inferInsert> = {}) {
+  return {
+    id: crypto.randomUUID(),
+    email: uniqueEmail(),
+    name: "Test User",
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+/** Insert a user into the real DB and return the row. */
+export async function createUser(overrides: Partial<typeof users.$inferInsert> = {}) {
+  const [row] = await db.insert(users).values(buildUser(overrides)).returning();
+  return row;
+}
+```
+
+## Usage in Unit Tests
+
+```typescript
+import { buildUser } from "../factories/user.factory";
+
+test("formats display name", () => {
+  const user = buildUser({ name: "Jane Doe" });
+  expect(formatDisplayName(user)).toBe("Jane Doe");
+});
+```
+
+## Usage in Integration Tests
+
+```typescript
+// tests/integration/users.test.ts
+import { createUser } from "../factories/user.factory";
+
+test("GET /api/users/:id returns the user", async () => {
+  const user = await createUser({ name: "Integration User" });
+  const res = await fetch(`http://localhost:3015/api/users/${user.id}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.name).toBe("Integration User");
+});
+```
+
+## Rules
+
+- `build*` functions return plain objects — no DB calls, safe for unit tests.
+- `create*` functions insert into the real DB — use only in integration tests.
+- Always clean up after integration tests (use `afterEach` with `db.delete(...)` or run tests in transactions that roll back).
+- Use counters or timestamps to ensure unique values across parallel test runs.


### PR DESCRIPTION
## Summary
- add a reusable Docker Compose local dev stack
- add template Makefile targets for compose lifecycle and integration tests
- add generic test factory guidance for real-DB integration tests

## Testing
- config/docs only

## Notes
This ports the durable parts of the older DX/testing PR into the current template architecture instead of reviving the stale branch directly. Supersedes #12 for this slice.