### PR TITLE
fix: harden watchdog QA terminal state handling

### DIFF
--- a/ralph/ralph-watchdog.sh
+++ b/ralph/ralph-watchdog.sh
@@ -219,28 +219,13 @@ PY
 }
 
 write_final_status() {
-  local total qa_passed build_passed exhausted blocked
+  local total qa_passed build_passed exhausted blocked qa_state_json
+  qa_state_json="$(qa_state_snapshot)"
   total=$(total_tasks)
-  qa_passed=$($PY -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
+  qa_passed=$(printf '%s' "$qa_state_json" | $PY -c "import json,sys; print(json.load(sys.stdin).get('qa_passed', 0))" 2>/dev/null || echo "0")
   build_passed=$(count_passes)
-  exhausted=$($PY - <<'PY' 2>/dev/null || echo "0"
-import json
-from collections import Counter
-try:
-    report = json.load(open('qa-report.json'))
-except Exception:
-    print(0)
-    raise SystemExit
-counts = Counter(item.get('feature_id') for item in report if item.get('feature_id'))
-prd = json.load(open('prd.json'))
-qa_passed = {item['id'] for item in prd if item.get('qa_pass', False)}
-print(sum(1 for fid, count in counts.items() if count >= 3 and fid not in qa_passed))
-PY
-)
-  blocked=$(( total - qa_passed - exhausted ))
-  if [ "$blocked" -lt 0 ]; then
-    blocked=0
-  fi
+  exhausted=$(printf '%s' "$qa_state_json" | $PY -c "import json,sys; print(json.load(sys.stdin).get('exhausted', 0))" 2>/dev/null || echo "0")
+  blocked=$(printf '%s' "$qa_state_json" | $PY -c "import json,sys; print(json.load(sys.stdin).get('actionable_remaining', 0))" 2>/dev/null || echo "0")
 
   _WD_STATUS="$RUN_STATUS" \
   _WD_REASON="$RUN_STATUS_REASON" \
@@ -383,44 +368,85 @@ all_passed() {
   [ "$total" -gt 0 ] && [ "$passed" -ge "$total" ]
 }
 
-qa_complete() {
-  $PY -c "
-import json
-prd = json.load(open('prd.json'))
-unverified = [item['id'] for item in prd if not item.get('qa_pass', False)]
-if unverified:
-    print('false')
-else:
-    print('true')
-" 2>/dev/null || echo "false"
-}
-
-qa_progress_snapshot() {
-  $PY - <<'PY' 2>/dev/null || echo "0:0:0"
+qa_state_snapshot() {
+  $PY - <<'PY' 2>/dev/null || echo '{"total":0,"qa_passed":0,"exhausted":0,"failed":0,"crashed":0,"done":0,"actionable_remaining":0,"all_done":false,"all_passed":false,"report_entries":0}'
 import json
 from pathlib import Path
 
-qa_passed = 0
-qa_remaining = 0
-qa_report_entries = 0
+payload = {
+    'total': 0,
+    'qa_passed': 0,
+    'exhausted': 0,
+    'failed': 0,
+    'crashed': 0,
+    'done': 0,
+    'actionable_remaining': 0,
+    'all_done': False,
+    'all_passed': False,
+    'report_entries': 0,
+}
 
 try:
     prd = json.load(open('prd.json'))
-    qa_passed = sum(1 for item in prd if item.get('qa_pass', False))
-    qa_remaining = sum(1 for item in prd if not item.get('qa_pass', False))
+    payload['total'] = len(prd)
+    payload['qa_passed'] = sum(1 for item in prd if item.get('qa_pass', False))
 except Exception:
-    pass
+    print(json.dumps(payload))
+    raise SystemExit
 
 qa_report_path = Path('qa-report.json')
 if qa_report_path.exists():
     try:
         qa_report = json.load(open(qa_report_path))
         if isinstance(qa_report, list):
-            qa_report_entries = len(qa_report)
+            payload['report_entries'] = len(qa_report)
     except Exception:
         pass
 
-print(f"{qa_passed}:{qa_remaining}:{qa_report_entries}")
+summary_path = Path('qa-report-summary.json')
+if summary_path.exists():
+    try:
+        summary = json.load(open(summary_path))
+        totals = summary.get('totals', {})
+        payload['qa_passed'] = int(totals.get('features_passed', payload['qa_passed']))
+        payload['exhausted'] = int(totals.get('features_exhausted', 0))
+        payload['failed'] = int(totals.get('features_failed', 0))
+        payload['crashed'] = int(totals.get('features_crashed', 0))
+    except Exception:
+        pass
+
+payload['done'] = payload['qa_passed'] + payload['exhausted']
+payload['actionable_remaining'] = payload['total'] - payload['done']
+if payload['actionable_remaining'] < 0:
+    payload['actionable_remaining'] = 0
+payload['all_done'] = payload['done'] >= payload['total'] and payload['total'] > 0
+payload['all_passed'] = payload['qa_passed'] >= payload['total'] and payload['total'] > 0
+
+print(json.dumps(payload))
+PY
+}
+
+qa_complete() {
+  _WD_QA_STATE="$(qa_state_snapshot)" $PY - <<'PY' 2>/dev/null || echo "false"
+import json, os
+state = json.loads(os.environ['_WD_QA_STATE'])
+print('true' if state.get('all_done') else 'false')
+PY
+}
+
+qa_all_passed() {
+  _WD_QA_STATE="$(qa_state_snapshot)" $PY - <<'PY' 2>/dev/null || echo "false"
+import json, os
+state = json.loads(os.environ['_WD_QA_STATE'])
+print('true' if state.get('all_passed') else 'false')
+PY
+}
+
+qa_progress_snapshot() {
+  _WD_QA_STATE="$(qa_state_snapshot)" $PY - <<'PY' 2>/dev/null || echo "0:0:0:0"
+import json, os
+state = json.loads(os.environ['_WD_QA_STATE'])
+print(f"{state.get('qa_passed', 0)}:{state.get('actionable_remaining', 0)}:{state.get('report_entries', 0)}:{state.get('exhausted', 0)}")
 PY
 }
 
@@ -634,22 +660,23 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
     fi
     rm -f "$PHASE_LOG_TMP"
 
-    IFS=':' read -r QA_BEFORE_PASSED QA_BEFORE_REMAINING QA_BEFORE_REPORTS <<< "$QA_BEFORE_SNAPSHOT"
-    IFS=':' read -r QA_AFTER_PASSED QA_AFTER_REMAINING QA_AFTER_REPORTS <<< "$QA_AFTER_SNAPSHOT"
+    IFS=':' read -r QA_BEFORE_PASSED QA_BEFORE_REMAINING QA_BEFORE_REPORTS QA_BEFORE_EXHAUSTED <<< "$QA_BEFORE_SNAPSHOT"
+    IFS=':' read -r QA_AFTER_PASSED QA_AFTER_REMAINING QA_AFTER_REPORTS QA_AFTER_EXHAUSTED <<< "$QA_AFTER_SNAPSHOT"
 
     QA_PROGRESS_MADE=false
     if [ "$QA_AFTER_PASSED" -gt "$QA_BEFORE_PASSED" ] || \
        [ "$QA_AFTER_REMAINING" -lt "$QA_BEFORE_REMAINING" ] || \
-       [ "$QA_AFTER_REPORTS" -gt "$QA_BEFORE_REPORTS" ]; then
+       [ "$QA_AFTER_REPORTS" -gt "$QA_BEFORE_REPORTS" ] || \
+       [ "$QA_AFTER_EXHAUSTED" -gt "$QA_BEFORE_EXHAUSTED" ]; then
       QA_PROGRESS_MADE=true
     fi
 
     if [ "$QA_PROGRESS_MADE" = true ]; then
       qa_stall_count=0
-      log "Phase 3: QA made forward progress (qa_pass ${QA_BEFORE_PASSED}->${QA_AFTER_PASSED}, remaining ${QA_BEFORE_REMAINING}->${QA_AFTER_REMAINING}, reports ${QA_BEFORE_REPORTS}->${QA_AFTER_REPORTS}, runtime=${QA_RUNTIME}s)."
+      log "Phase 3: QA made forward progress (qa_pass ${QA_BEFORE_PASSED}->${QA_AFTER_PASSED}, actionable ${QA_BEFORE_REMAINING}->${QA_AFTER_REMAINING}, reports ${QA_BEFORE_REPORTS}->${QA_AFTER_REPORTS}, exhausted ${QA_BEFORE_EXHAUSTED}->${QA_AFTER_EXHAUSTED}, runtime=${QA_RUNTIME}s)."
     else
       qa_stall_count=$((qa_stall_count + 1))
-      log "Phase 3: QA made no forward progress (qa_pass=${QA_AFTER_PASSED}, remaining=${QA_AFTER_REMAINING}, reports=${QA_AFTER_REPORTS}, runtime=${QA_RUNTIME}s, stall=${qa_stall_count}/${QA_STALL_THRESHOLD})."
+      log "Phase 3: QA made no forward progress (qa_pass=${QA_AFTER_PASSED}, actionable=${QA_AFTER_REMAINING}, reports=${QA_AFTER_REPORTS}, exhausted=${QA_AFTER_EXHAUSTED}, runtime=${QA_RUNTIME}s, stall=${qa_stall_count}/${QA_STALL_THRESHOLD})."
     fi
 
     if [ "$(qa_complete)" != "true" ]; then
@@ -664,7 +691,7 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
 
     if [ "$QA_PROGRESS_MADE" = false ] && [ "$qa_stall_count" -ge "$QA_STALL_THRESHOLD" ]; then
       qa_stalled=true
-      log "Phase 3: QA_STALLED after $qa_stall_count consecutive zero-progress attempts. Remaining QA work: $QA_AFTER_REMAINING features."
+      log "Phase 3: QA_STALLED after $qa_stall_count consecutive zero-progress attempts. Remaining actionable QA work: $QA_AFTER_REMAINING features."
       log "Phase 3: Stopping honestly instead of relaunching QA with no forward motion."
       cron_backup
       break
@@ -674,26 +701,36 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
   done
 
   QA_STATUS=$(qa_complete)
-  QA_PASSED=$($PY -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
+  QA_STATE_JSON="$(qa_state_snapshot)"
+  QA_PASSED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('qa_passed', 0))" 2>/dev/null || echo "0")
+  QA_EXHAUSTED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('exhausted', 0))" 2>/dev/null || echo "0")
+  QA_ACTIONABLE=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('actionable_remaining', 0))" 2>/dev/null || echo "0")
   TOTAL=$(total_tasks)
 
-  if [ "$QA_STATUS" = "true" ] && all_passed; then
+  if [ "$(qa_all_passed)" = "true" ] && all_passed; then
     RUN_STATUS="SUCCESS"
     RUN_STATUS_REASON="All features built and QA verified"
-    log "=== ALL $TOTAL FEATURES: BUILT + QA VERIFIED ($QA_PASSED/$TOTAL qa_pass) ==="
+    log "=== ALL $TOTAL FEATURES: BUILT + QA VERIFIED ($QA_PASSED/$TOTAL qa_pass, exhausted=$QA_EXHAUSTED) ==="
+    break
+  fi
+
+  if [ "$QA_STATUS" = "true" ]; then
+    RUN_STATUS="INCOMPLETE_QA"
+    RUN_STATUS_REASON="All QA items reached terminal states, but not all features passed"
+    log "Phase 3: QA reached terminal completion without full pass coverage. QA passed: $QA_PASSED/$TOTAL. Exhausted: $QA_EXHAUSTED. Build passes: $(count_passes)/$TOTAL."
     break
   fi
 
   if [ "$qa_stalled" = true ]; then
     RUN_STATUS="QA_STALLED"
     RUN_STATUS_REASON="Repeated QA attempts made zero forward progress"
-    log "Phase 3: Cycle $cycle terminated with QA_STALLED. QA passed: $QA_PASSED/$TOTAL. Build passes: $(count_passes)/$TOTAL."
+    log "Phase 3: Cycle $cycle terminated with QA_STALLED. QA passed: $QA_PASSED/$TOTAL. Exhausted: $QA_EXHAUSTED. Build passes: $(count_passes)/$TOTAL."
     break
   fi
 
-  log "Phase 3: Cycle $cycle done. QA passed: $QA_PASSED/$TOTAL. Build passes: $(count_passes)/$TOTAL."
+  log "Phase 3: Cycle $cycle done. QA passed: $QA_PASSED/$TOTAL. Exhausted: $QA_EXHAUSTED. Build passes: $(count_passes)/$TOTAL."
   if [ "$QA_STATUS" != "true" ]; then
-    log "Phase 3: QA incomplete — $(($TOTAL - $QA_PASSED)) features not qa_pass. Restarting QA..."
+    log "Phase 3: QA incomplete — $QA_ACTIONABLE actionable features remain. Restarting QA..."
   else
     AFTER_QA=$(count_passes)
     REMAINING=$(($TOTAL - $AFTER_QA))
@@ -702,12 +739,12 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
 done
 
 if [ "$RUN_STATUS" = "IN_PROGRESS" ]; then
-  if [ "$(qa_complete)" = "true" ] && all_passed; then
+  if [ "$(qa_all_passed)" = "true" ] && all_passed; then
     RUN_STATUS="SUCCESS"
     RUN_STATUS_REASON="All features built and QA verified"
-  elif all_passed; then
+  elif [ "$(qa_complete)" = "true" ]; then
     RUN_STATUS="INCOMPLETE_QA"
-    RUN_STATUS_REASON="Build completed but QA did not finish"
+    RUN_STATUS_REASON="All QA items reached terminal states, but not all features passed"
   else
     RUN_STATUS="BUILD_INCOMPLETE"
     RUN_STATUS_REASON="Build loop ended without all features passing"
@@ -723,25 +760,10 @@ MINUTES=$(( (ELAPSED % 3600) / 60 ))
 SECONDS_LEFT=$(( ELAPSED % 60 ))
 TOTAL=$(total_tasks)
 BUILD_PASSED=$(count_passes)
-QA_PASSED=$($PY -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
-EXHAUSTED=$($PY - <<'PY' 2>/dev/null || echo "0"
-import json
-from collections import Counter
-try:
-    report = json.load(open('qa-report.json'))
-except Exception:
-    print(0)
-    raise SystemExit
-counts = Counter(item.get('feature_id') for item in report if item.get('feature_id'))
-prd = json.load(open('prd.json'))
-qa_passed = {item['id'] for item in prd if item.get('qa_pass', False)}
-print(sum(1 for fid, count in counts.items() if count >= 3 and fid not in qa_passed))
-PY
-)
-BLOCKED=$(( TOTAL - QA_PASSED - EXHAUSTED ))
-if [ "$BLOCKED" -lt 0 ]; then
-  BLOCKED=0
-fi
+QA_STATE_JSON="$(qa_state_snapshot)"
+QA_PASSED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('qa_passed', 0))" 2>/dev/null || echo "0")
+EXHAUSTED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('exhausted', 0))" 2>/dev/null || echo "0")
+BLOCKED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('actionable_remaining', 0))" 2>/dev/null || echo "0")
 
 log ""
 log "========================================="

--- a/ralph/ralph-watchdog.sh
+++ b/ralph/ralph-watchdog.sh
@@ -16,9 +16,6 @@ LOCKFILE=".ralph-watchdog.lock"
 LOG_FILE="ralph-watchdog-$(date +%Y%m%d-%H%M%S).log"
 COST_LOG="ralph/cost-log.json"
 FAILURE_LOG="ralph/failure-log.json"
-FINAL_STATUS_FILE="ralph/final-status.json"
-RUN_STATUS="IN_PROGRESS"
-RUN_STATUS_REASON=""
 
 log() { echo "[$(date '+%H:%M:%S')] $1" | tee -a "$LOG_FILE"; }
 
@@ -210,49 +207,10 @@ PY
   [ -n "$budget_output" ] && echo "$budget_output"
 
   if [ "$budget_status" -eq 2 ]; then
-    RUN_STATUS="BLOCKED"
-    RUN_STATUS_REASON="Budget exceeded"
     log "BUDGET EXCEEDED — stopping. See $COST_LOG for details."
     print_cost_summary
     exit 1
   fi
-}
-
-write_final_status() {
-  local total qa_passed build_passed exhausted blocked qa_state_json
-  qa_state_json="$(qa_state_snapshot)"
-  total=$(total_tasks)
-  qa_passed=$(printf '%s' "$qa_state_json" | $PY -c "import json,sys; print(json.load(sys.stdin).get('qa_passed', 0))" 2>/dev/null || echo "0")
-  build_passed=$(count_passes)
-  exhausted=$(printf '%s' "$qa_state_json" | $PY -c "import json,sys; print(json.load(sys.stdin).get('exhausted', 0))" 2>/dev/null || echo "0")
-  blocked=$(printf '%s' "$qa_state_json" | $PY -c "import json,sys; print(json.load(sys.stdin).get('actionable_remaining', 0))" 2>/dev/null || echo "0")
-
-  _WD_STATUS="$RUN_STATUS" \
-  _WD_REASON="$RUN_STATUS_REASON" \
-  _WD_TOTAL="$total" \
-  _WD_QA="$qa_passed" \
-  _WD_BUILD="$build_passed" \
-  _WD_EXHAUSTED="$exhausted" \
-  _WD_BLOCKED="$blocked" \
-  _WD_LOG="$LOG_FILE" \
-  _WD_FINAL_STATUS_FILE="$FINAL_STATUS_FILE" \
-  $PY - <<'PY'
-import json, os
-payload = {
-    'status': os.environ['_WD_STATUS'],
-    'reason': os.environ['_WD_REASON'],
-    'counts': {
-        'total': int(os.environ['_WD_TOTAL']),
-        'build_passed': int(os.environ['_WD_BUILD']),
-        'qa_passed': int(os.environ['_WD_QA']),
-        'exhausted': int(os.environ['_WD_EXHAUSTED']),
-        'blocked': int(os.environ['_WD_BLOCKED']),
-    },
-    'logFile': os.environ['_WD_LOG'],
-}
-with open(os.environ['_WD_FINAL_STATUS_FILE'], 'w') as f:
-    json.dump(payload, f, indent=2)
-PY
 }
 
 print_cost_summary() {
@@ -368,85 +326,44 @@ all_passed() {
   [ "$total" -gt 0 ] && [ "$passed" -ge "$total" ]
 }
 
-qa_state_snapshot() {
-  $PY - <<'PY' 2>/dev/null || echo '{"total":0,"qa_passed":0,"exhausted":0,"failed":0,"crashed":0,"done":0,"actionable_remaining":0,"all_done":false,"all_passed":false,"report_entries":0}'
+qa_complete() {
+  $PY -c "
+import json
+prd = json.load(open('prd.json'))
+unverified = [item['id'] for item in prd if not item.get('qa_pass', False)]
+if unverified:
+    print('false')
+else:
+    print('true')
+" 2>/dev/null || echo "false"
+}
+
+qa_progress_snapshot() {
+  $PY - <<'PY' 2>/dev/null || echo "0:0:0"
 import json
 from pathlib import Path
 
-payload = {
-    'total': 0,
-    'qa_passed': 0,
-    'exhausted': 0,
-    'failed': 0,
-    'crashed': 0,
-    'done': 0,
-    'actionable_remaining': 0,
-    'all_done': False,
-    'all_passed': False,
-    'report_entries': 0,
-}
+qa_passed = 0
+qa_remaining = 0
+qa_report_entries = 0
 
 try:
     prd = json.load(open('prd.json'))
-    payload['total'] = len(prd)
-    payload['qa_passed'] = sum(1 for item in prd if item.get('qa_pass', False))
+    qa_passed = sum(1 for item in prd if item.get('qa_pass', False))
+    qa_remaining = sum(1 for item in prd if not item.get('qa_pass', False))
 except Exception:
-    print(json.dumps(payload))
-    raise SystemExit
+    pass
 
 qa_report_path = Path('qa-report.json')
 if qa_report_path.exists():
     try:
         qa_report = json.load(open(qa_report_path))
         if isinstance(qa_report, list):
-            payload['report_entries'] = len(qa_report)
+            qa_report_entries = len(qa_report)
     except Exception:
         pass
 
-summary_path = Path('qa-report-summary.json')
-if summary_path.exists():
-    try:
-        summary = json.load(open(summary_path))
-        totals = summary.get('totals', {})
-        payload['qa_passed'] = int(totals.get('features_passed', payload['qa_passed']))
-        payload['exhausted'] = int(totals.get('features_exhausted', 0))
-        payload['failed'] = int(totals.get('features_failed', 0))
-        payload['crashed'] = int(totals.get('features_crashed', 0))
-    except Exception:
-        pass
-
-payload['done'] = payload['qa_passed'] + payload['exhausted']
-payload['actionable_remaining'] = payload['total'] - payload['done']
-if payload['actionable_remaining'] < 0:
-    payload['actionable_remaining'] = 0
-payload['all_done'] = payload['done'] >= payload['total'] and payload['total'] > 0
-payload['all_passed'] = payload['qa_passed'] >= payload['total'] and payload['total'] > 0
-
-print(json.dumps(payload))
-PY
-}
-
-qa_complete() {
-  _WD_QA_STATE="$(qa_state_snapshot)" $PY - <<'PY' 2>/dev/null || echo "false"
-import json, os
-state = json.loads(os.environ['_WD_QA_STATE'])
-print('true' if state.get('all_done') else 'false')
-PY
-}
-
-qa_all_passed() {
-  _WD_QA_STATE="$(qa_state_snapshot)" $PY - <<'PY' 2>/dev/null || echo "false"
-import json, os
-state = json.loads(os.environ['_WD_QA_STATE'])
-print('true' if state.get('all_passed') else 'false')
-PY
-}
-
-qa_progress_snapshot() {
-  _WD_QA_STATE="$(qa_state_snapshot)" $PY - <<'PY' 2>/dev/null || echo "0:0:0:0"
-import json, os
-state = json.loads(os.environ['_WD_QA_STATE'])
-print(f"{state.get('qa_passed', 0)}:{state.get('actionable_remaining', 0)}:{state.get('report_entries', 0)}:{state.get('exhausted', 0)}")
+print(f"{qa_passed}:{qa_remaining}:{qa_report_entries}")
 PY
 }
 
@@ -601,7 +518,7 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
     cron_backup
 
     if all_passed; then
-      log "Phase 2: All $(total_tasks) features report build_pass."
+      log "Phase 2: All $(total_tasks) features pass!"
       break
     fi
 
@@ -660,23 +577,22 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
     fi
     rm -f "$PHASE_LOG_TMP"
 
-    IFS=':' read -r QA_BEFORE_PASSED QA_BEFORE_REMAINING QA_BEFORE_REPORTS QA_BEFORE_EXHAUSTED <<< "$QA_BEFORE_SNAPSHOT"
-    IFS=':' read -r QA_AFTER_PASSED QA_AFTER_REMAINING QA_AFTER_REPORTS QA_AFTER_EXHAUSTED <<< "$QA_AFTER_SNAPSHOT"
+    IFS=':' read -r QA_BEFORE_PASSED QA_BEFORE_REMAINING QA_BEFORE_REPORTS <<< "$QA_BEFORE_SNAPSHOT"
+    IFS=':' read -r QA_AFTER_PASSED QA_AFTER_REMAINING QA_AFTER_REPORTS <<< "$QA_AFTER_SNAPSHOT"
 
     QA_PROGRESS_MADE=false
     if [ "$QA_AFTER_PASSED" -gt "$QA_BEFORE_PASSED" ] || \
        [ "$QA_AFTER_REMAINING" -lt "$QA_BEFORE_REMAINING" ] || \
-       [ "$QA_AFTER_REPORTS" -gt "$QA_BEFORE_REPORTS" ] || \
-       [ "$QA_AFTER_EXHAUSTED" -gt "$QA_BEFORE_EXHAUSTED" ]; then
+       [ "$QA_AFTER_REPORTS" -gt "$QA_BEFORE_REPORTS" ]; then
       QA_PROGRESS_MADE=true
     fi
 
     if [ "$QA_PROGRESS_MADE" = true ]; then
       qa_stall_count=0
-      log "Phase 3: QA made forward progress (qa_pass ${QA_BEFORE_PASSED}->${QA_AFTER_PASSED}, actionable ${QA_BEFORE_REMAINING}->${QA_AFTER_REMAINING}, reports ${QA_BEFORE_REPORTS}->${QA_AFTER_REPORTS}, exhausted ${QA_BEFORE_EXHAUSTED}->${QA_AFTER_EXHAUSTED}, runtime=${QA_RUNTIME}s)."
+      log "Phase 3: QA made forward progress (qa_pass ${QA_BEFORE_PASSED}->${QA_AFTER_PASSED}, remaining ${QA_BEFORE_REMAINING}->${QA_AFTER_REMAINING}, reports ${QA_BEFORE_REPORTS}->${QA_AFTER_REPORTS}, runtime=${QA_RUNTIME}s)."
     else
       qa_stall_count=$((qa_stall_count + 1))
-      log "Phase 3: QA made no forward progress (qa_pass=${QA_AFTER_PASSED}, actionable=${QA_AFTER_REMAINING}, reports=${QA_AFTER_REPORTS}, exhausted=${QA_AFTER_EXHAUSTED}, runtime=${QA_RUNTIME}s, stall=${qa_stall_count}/${QA_STALL_THRESHOLD})."
+      log "Phase 3: QA made no forward progress (qa_pass=${QA_AFTER_PASSED}, remaining=${QA_AFTER_REMAINING}, reports=${QA_AFTER_REPORTS}, runtime=${QA_RUNTIME}s, stall=${qa_stall_count}/${QA_STALL_THRESHOLD})."
     fi
 
     if [ "$(qa_complete)" != "true" ]; then
@@ -691,7 +607,7 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
 
     if [ "$QA_PROGRESS_MADE" = false ] && [ "$qa_stall_count" -ge "$QA_STALL_THRESHOLD" ]; then
       qa_stalled=true
-      log "Phase 3: QA_STALLED after $qa_stall_count consecutive zero-progress attempts. Remaining actionable QA work: $QA_AFTER_REMAINING features."
+      log "Phase 3: QA_STALLED after $qa_stall_count consecutive zero-progress attempts. Remaining QA work: $QA_AFTER_REMAINING features."
       log "Phase 3: Stopping honestly instead of relaunching QA with no forward motion."
       cron_backup
       break
@@ -701,36 +617,22 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
   done
 
   QA_STATUS=$(qa_complete)
-  QA_STATE_JSON="$(qa_state_snapshot)"
-  QA_PASSED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('qa_passed', 0))" 2>/dev/null || echo "0")
-  QA_EXHAUSTED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('exhausted', 0))" 2>/dev/null || echo "0")
-  QA_ACTIONABLE=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('actionable_remaining', 0))" 2>/dev/null || echo "0")
+  QA_PASSED=$($PY -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
   TOTAL=$(total_tasks)
 
-  if [ "$(qa_all_passed)" = "true" ] && all_passed; then
-    RUN_STATUS="SUCCESS"
-    RUN_STATUS_REASON="All features built and QA verified"
-    log "=== ALL $TOTAL FEATURES: BUILT + QA VERIFIED ($QA_PASSED/$TOTAL qa_pass, exhausted=$QA_EXHAUSTED) ==="
-    break
-  fi
-
-  if [ "$QA_STATUS" = "true" ]; then
-    RUN_STATUS="INCOMPLETE_QA"
-    RUN_STATUS_REASON="All QA items reached terminal states, but not all features passed"
-    log "Phase 3: QA reached terminal completion without full pass coverage. QA passed: $QA_PASSED/$TOTAL. Exhausted: $QA_EXHAUSTED. Build passes: $(count_passes)/$TOTAL."
+  if [ "$QA_STATUS" = "true" ] && all_passed; then
+    log "=== ALL $TOTAL FEATURES: BUILT + QA VERIFIED ($QA_PASSED/$TOTAL qa_pass) ==="
     break
   fi
 
   if [ "$qa_stalled" = true ]; then
-    RUN_STATUS="QA_STALLED"
-    RUN_STATUS_REASON="Repeated QA attempts made zero forward progress"
-    log "Phase 3: Cycle $cycle terminated with QA_STALLED. QA passed: $QA_PASSED/$TOTAL. Exhausted: $QA_EXHAUSTED. Build passes: $(count_passes)/$TOTAL."
+    log "Phase 3: Cycle $cycle terminated with QA_STALLED. QA passed: $QA_PASSED/$TOTAL. Build passes: $(count_passes)/$TOTAL."
     break
   fi
 
-  log "Phase 3: Cycle $cycle done. QA passed: $QA_PASSED/$TOTAL. Exhausted: $QA_EXHAUSTED. Build passes: $(count_passes)/$TOTAL."
+  log "Phase 3: Cycle $cycle done. QA passed: $QA_PASSED/$TOTAL. Build passes: $(count_passes)/$TOTAL."
   if [ "$QA_STATUS" != "true" ]; then
-    log "Phase 3: QA incomplete — $QA_ACTIONABLE actionable features remain. Restarting QA..."
+    log "Phase 3: QA incomplete — $(($TOTAL - $QA_PASSED)) features not qa_pass. Restarting QA..."
   else
     AFTER_QA=$(count_passes)
     REMAINING=$(($TOTAL - $AFTER_QA))
@@ -738,54 +640,19 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
   fi
 done
 
-if [ "$RUN_STATUS" = "IN_PROGRESS" ]; then
-  if [ "$(qa_all_passed)" = "true" ] && all_passed; then
-    RUN_STATUS="SUCCESS"
-    RUN_STATUS_REASON="All features built and QA verified"
-  elif [ "$(qa_complete)" = "true" ]; then
-    RUN_STATUS="INCOMPLETE_QA"
-    RUN_STATUS_REASON="All QA items reached terminal states, but not all features passed"
-  else
-    RUN_STATUS="BUILD_INCOMPLETE"
-    RUN_STATUS_REASON="Build loop ended without all features passing"
-  fi
-fi
-
 cron_backup
-write_final_status
 END_TIME=$(date +%s)
 ELAPSED=$(( END_TIME - START_TIME ))
 HOURS=$(( ELAPSED / 3600 ))
 MINUTES=$(( (ELAPSED % 3600) / 60 ))
 SECONDS_LEFT=$(( ELAPSED % 60 ))
-TOTAL=$(total_tasks)
-BUILD_PASSED=$(count_passes)
-QA_STATE_JSON="$(qa_state_snapshot)"
-QA_PASSED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('qa_passed', 0))" 2>/dev/null || echo "0")
-EXHAUSTED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('exhausted', 0))" 2>/dev/null || echo "0")
-BLOCKED=$(printf '%s' "$QA_STATE_JSON" | $PY -c "import json,sys; print(json.load(sys.stdin).get('actionable_remaining', 0))" 2>/dev/null || echo "0")
-
 log ""
 log "========================================="
-log "  RALPH-TO-RALPH ${RUN_STATUS}"
-log "  Reason: ${RUN_STATUS_REASON}"
-log "  Build passed: ${BUILD_PASSED}/${TOTAL}"
-log "  QA passed: ${QA_PASSED}/${TOTAL}"
-log "  Exhausted: ${EXHAUSTED}"
-log "  Blocked: ${BLOCKED}"
+log "  RALPH-TO-RALPH COMPLETE"
+log "  Features: $(count_passes)/$(total_tasks) passed"
 log "  QA Report: qa-report.json"
-log "  Final Status: ${FINAL_STATUS_FILE}"
 log "  End time: $(date '+%Y-%m-%d %H:%M:%S')"
 log "  Duration: ${HOURS}h ${MINUTES}m ${SECONDS_LEFT}s"
 log "  Cost Summary:"
 print_cost_summary | while IFS= read -r line; do log "$line"; done
 log "========================================="
-
-case "$RUN_STATUS" in
-  SUCCESS)
-    exit 0
-    ;;
-  *)
-    exit 1
-    ;;
-esac

--- a/ralph/ralph-watchdog.sh
+++ b/ralph/ralph-watchdog.sh
@@ -16,6 +16,9 @@ LOCKFILE=".ralph-watchdog.lock"
 LOG_FILE="ralph-watchdog-$(date +%Y%m%d-%H%M%S).log"
 COST_LOG="ralph/cost-log.json"
 FAILURE_LOG="ralph/failure-log.json"
+FINAL_STATUS_FILE="ralph/final-status.json"
+RUN_STATUS="IN_PROGRESS"
+RUN_STATUS_REASON=""
 
 log() { echo "[$(date '+%H:%M:%S')] $1" | tee -a "$LOG_FILE"; }
 
@@ -207,10 +210,64 @@ PY
   [ -n "$budget_output" ] && echo "$budget_output"
 
   if [ "$budget_status" -eq 2 ]; then
+    RUN_STATUS="BLOCKED"
+    RUN_STATUS_REASON="Budget exceeded"
     log "BUDGET EXCEEDED — stopping. See $COST_LOG for details."
     print_cost_summary
     exit 1
   fi
+}
+
+write_final_status() {
+  local total qa_passed build_passed exhausted blocked
+  total=$(total_tasks)
+  qa_passed=$($PY -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
+  build_passed=$(count_passes)
+  exhausted=$($PY - <<'PY' 2>/dev/null || echo "0"
+import json
+from collections import Counter
+try:
+    report = json.load(open('qa-report.json'))
+except Exception:
+    print(0)
+    raise SystemExit
+counts = Counter(item.get('feature_id') for item in report if item.get('feature_id'))
+prd = json.load(open('prd.json'))
+qa_passed = {item['id'] for item in prd if item.get('qa_pass', False)}
+print(sum(1 for fid, count in counts.items() if count >= 3 and fid not in qa_passed))
+PY
+)
+  blocked=$(( total - qa_passed - exhausted ))
+  if [ "$blocked" -lt 0 ]; then
+    blocked=0
+  fi
+
+  _WD_STATUS="$RUN_STATUS" \
+  _WD_REASON="$RUN_STATUS_REASON" \
+  _WD_TOTAL="$total" \
+  _WD_QA="$qa_passed" \
+  _WD_BUILD="$build_passed" \
+  _WD_EXHAUSTED="$exhausted" \
+  _WD_BLOCKED="$blocked" \
+  _WD_LOG="$LOG_FILE" \
+  _WD_FINAL_STATUS_FILE="$FINAL_STATUS_FILE" \
+  $PY - <<'PY'
+import json, os
+payload = {
+    'status': os.environ['_WD_STATUS'],
+    'reason': os.environ['_WD_REASON'],
+    'counts': {
+        'total': int(os.environ['_WD_TOTAL']),
+        'build_passed': int(os.environ['_WD_BUILD']),
+        'qa_passed': int(os.environ['_WD_QA']),
+        'exhausted': int(os.environ['_WD_EXHAUSTED']),
+        'blocked': int(os.environ['_WD_BLOCKED']),
+    },
+    'logFile': os.environ['_WD_LOG'],
+}
+with open(os.environ['_WD_FINAL_STATUS_FILE'], 'w') as f:
+    json.dump(payload, f, indent=2)
+PY
 }
 
 print_cost_summary() {
@@ -621,11 +678,15 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
   TOTAL=$(total_tasks)
 
   if [ "$QA_STATUS" = "true" ] && all_passed; then
+    RUN_STATUS="SUCCESS"
+    RUN_STATUS_REASON="All features built and QA verified"
     log "=== ALL $TOTAL FEATURES: BUILT + QA VERIFIED ($QA_PASSED/$TOTAL qa_pass) ==="
     break
   fi
 
   if [ "$qa_stalled" = true ]; then
+    RUN_STATUS="QA_STALLED"
+    RUN_STATUS_REASON="Repeated QA attempts made zero forward progress"
     log "Phase 3: Cycle $cycle terminated with QA_STALLED. QA passed: $QA_PASSED/$TOTAL. Build passes: $(count_passes)/$TOTAL."
     break
   fi
@@ -640,19 +701,69 @@ for ((cycle=1; cycle<=MAX_CYCLES; cycle++)); do
   fi
 done
 
+if [ "$RUN_STATUS" = "IN_PROGRESS" ]; then
+  if [ "$(qa_complete)" = "true" ] && all_passed; then
+    RUN_STATUS="SUCCESS"
+    RUN_STATUS_REASON="All features built and QA verified"
+  elif all_passed; then
+    RUN_STATUS="INCOMPLETE_QA"
+    RUN_STATUS_REASON="Build completed but QA did not finish"
+  else
+    RUN_STATUS="BUILD_INCOMPLETE"
+    RUN_STATUS_REASON="Build loop ended without all features passing"
+  fi
+fi
+
 cron_backup
+write_final_status
 END_TIME=$(date +%s)
 ELAPSED=$(( END_TIME - START_TIME ))
 HOURS=$(( ELAPSED / 3600 ))
 MINUTES=$(( (ELAPSED % 3600) / 60 ))
 SECONDS_LEFT=$(( ELAPSED % 60 ))
+TOTAL=$(total_tasks)
+BUILD_PASSED=$(count_passes)
+QA_PASSED=$($PY -c "import json; print(sum(1 for x in json.load(open('prd.json')) if x.get('qa_pass', False)))" 2>/dev/null || echo "0")
+EXHAUSTED=$($PY - <<'PY' 2>/dev/null || echo "0"
+import json
+from collections import Counter
+try:
+    report = json.load(open('qa-report.json'))
+except Exception:
+    print(0)
+    raise SystemExit
+counts = Counter(item.get('feature_id') for item in report if item.get('feature_id'))
+prd = json.load(open('prd.json'))
+qa_passed = {item['id'] for item in prd if item.get('qa_pass', False)}
+print(sum(1 for fid, count in counts.items() if count >= 3 and fid not in qa_passed))
+PY
+)
+BLOCKED=$(( TOTAL - QA_PASSED - EXHAUSTED ))
+if [ "$BLOCKED" -lt 0 ]; then
+  BLOCKED=0
+fi
+
 log ""
 log "========================================="
-log "  RALPH-TO-RALPH COMPLETE"
-log "  Features: $(count_passes)/$(total_tasks) passed"
+log "  RALPH-TO-RALPH ${RUN_STATUS}"
+log "  Reason: ${RUN_STATUS_REASON}"
+log "  Build passed: ${BUILD_PASSED}/${TOTAL}"
+log "  QA passed: ${QA_PASSED}/${TOTAL}"
+log "  Exhausted: ${EXHAUSTED}"
+log "  Blocked: ${BLOCKED}"
 log "  QA Report: qa-report.json"
+log "  Final Status: ${FINAL_STATUS_FILE}"
 log "  End time: $(date '+%Y-%m-%d %H:%M:%S')"
 log "  Duration: ${HOURS}h ${MINUTES}m ${SECONDS_LEFT}s"
 log "  Cost Summary:"
 print_cost_summary | while IFS= read -r line; do log "$line"; done
 log "========================================="
+
+case "$RUN_STATUS" in
+  SUCCESS)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac

--- a/tests/ralph-watchdog-verification.test.ts
+++ b/tests/ralph-watchdog-verification.test.ts
@@ -107,25 +107,35 @@ touch .qa-ran
   });
 
   it("resets stale flags and returns to build instead of starting QA when verification fails", () => {
-    execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
-      cwd: tmpDir,
-      env: {
-        ...process.env,
-        MAX_CYCLES: "2",
-        MAX_BUILD_RESTARTS: "1",
-        MAX_QA_RESTARTS: "1",
-        MAX_INSPECT_RESTARTS: "1",
-        WATCHDOG_VERIFY_CHECK_CMD: "true",
-        WATCHDOG_VERIFY_TEST_CMD: "false",
-        WATCHDOG_VERIFY_BUILD_CMD: "true",
-      },
-      encoding: "utf8",
-    });
+    let exitCode = 0;
+    try {
+      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
+        cwd: tmpDir,
+        env: {
+          ...process.env,
+          MAX_CYCLES: "2",
+          MAX_BUILD_RESTARTS: "1",
+          MAX_QA_RESTARTS: "1",
+          MAX_INSPECT_RESTARTS: "1",
+          WATCHDOG_VERIFY_CHECK_CMD: "true",
+          WATCHDOG_VERIFY_TEST_CMD: "false",
+          WATCHDOG_VERIFY_BUILD_CMD: "true",
+        },
+        encoding: "utf8",
+      });
+    } catch (error) {
+      exitCode = (error as { status?: number }).status ?? 1;
+    }
 
     const prd = JSON.parse(
       fs.readFileSync(path.join(tmpDir, "prd.json"), "utf8"),
     ) as Array<{ build_pass?: boolean; qa_pass?: boolean }>;
+    const finalStatus = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
+    ) as { status: string };
 
+    expect(exitCode).toBe(1);
+    expect(finalStatus.status).toBe("BUILD_INCOMPLETE");
     expect(
       fs.readFileSync(path.join(tmpDir, ".build-invocations"), "utf8"),
     ).toBe("2");
@@ -177,21 +187,26 @@ exit 0
       { mode: 0o755 },
     );
 
-    execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
-      cwd: tmpDir,
-      env: {
-        ...process.env,
-        MAX_CYCLES: "3",
-        MAX_BUILD_RESTARTS: "1",
-        MAX_QA_RESTARTS: "5",
-        MAX_INSPECT_RESTARTS: "1",
-        QA_STALL_THRESHOLD: "2",
-        WATCHDOG_VERIFY_CHECK_CMD: "true",
-        WATCHDOG_VERIFY_TEST_CMD: "true",
-        WATCHDOG_VERIFY_BUILD_CMD: "true",
-      },
-      encoding: "utf8",
-    });
+    let exitCode = 0;
+    try {
+      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
+        cwd: tmpDir,
+        env: {
+          ...process.env,
+          MAX_CYCLES: "3",
+          MAX_BUILD_RESTARTS: "1",
+          MAX_QA_RESTARTS: "5",
+          MAX_INSPECT_RESTARTS: "1",
+          QA_STALL_THRESHOLD: "2",
+          WATCHDOG_VERIFY_CHECK_CMD: "true",
+          WATCHDOG_VERIFY_TEST_CMD: "true",
+          WATCHDOG_VERIFY_BUILD_CMD: "true",
+        },
+        encoding: "utf8",
+      });
+    } catch (error) {
+      exitCode = (error as { status?: number }).status ?? 1;
+    }
 
     const qaInvocations = fs.readFileSync(
       path.join(tmpDir, ".qa-invocations"),
@@ -201,14 +216,103 @@ exit 0
       path.join(tmpDir, fs.readdirSync(tmpDir).find((f) => f.startsWith("ralph-watchdog-") && f.endsWith(".log"))!),
       "utf8",
     );
+    const finalStatus = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
+    ) as {
+      status: string;
+      counts: { build_passed: number; qa_passed: number; blocked: number };
+    };
     const prd = JSON.parse(
       fs.readFileSync(path.join(tmpDir, "prd.json"), "utf8"),
     ) as Array<{ build_pass?: boolean; qa_pass?: boolean }>;
 
+    expect(exitCode).toBe(1);
     expect(qaInvocations).toBe("2");
     expect(log).toContain("QA_STALLED");
+    expect(log).toContain("RALPH-TO-RALPH QA_STALLED");
     expect(log).toContain("Stopping honestly instead of relaunching QA with no forward motion.");
+    expect(finalStatus.status).toBe("QA_STALLED");
+    expect(finalStatus.counts.build_passed).toBe(1);
+    expect(finalStatus.counts.qa_passed).toBe(0);
+    expect(finalStatus.counts.blocked).toBe(1);
     expect(prd[0]?.build_pass).toBe(true);
     expect(prd[0]?.qa_pass).toBe(false);
+  });
+
+  it("reports INCOMPLETE_QA instead of a fake success footer when build finishes but QA does not", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "prd.json"),
+      JSON.stringify(
+        [
+          {
+            id: "feature-1",
+            description: "Test feature",
+            build_pass: true,
+            qa_pass: false,
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, "ralph/build-ralph.sh"),
+      `#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+`,
+      { mode: 0o755 },
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, "ralph/qa-ralph.sh"),
+      `#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    let exitCode = 0;
+    try {
+      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
+        cwd: tmpDir,
+        env: {
+          ...process.env,
+          MAX_CYCLES: "1",
+          MAX_BUILD_RESTARTS: "1",
+          MAX_QA_RESTARTS: "1",
+          MAX_INSPECT_RESTARTS: "1",
+          QA_STALL_THRESHOLD: "99",
+          WATCHDOG_VERIFY_CHECK_CMD: "true",
+          WATCHDOG_VERIFY_TEST_CMD: "true",
+          WATCHDOG_VERIFY_BUILD_CMD: "true",
+        },
+        encoding: "utf8",
+      });
+    } catch (error) {
+      exitCode = (error as { status?: number }).status ?? 1;
+    }
+
+    const log = fs.readFileSync(
+      path.join(tmpDir, fs.readdirSync(tmpDir).find((f) => f.startsWith("ralph-watchdog-") && f.endsWith(".log"))!),
+      "utf8",
+    );
+    const finalStatus = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
+    ) as {
+      status: string;
+      counts: { build_passed: number; qa_passed: number; blocked: number };
+    };
+
+    expect(exitCode).toBe(1);
+    expect(log).toContain("RALPH-TO-RALPH INCOMPLETE_QA");
+    expect(log).not.toContain("RALPH-TO-RALPH COMPLETE");
+    expect(finalStatus.status).toBe("INCOMPLETE_QA");
+    expect(finalStatus.counts.build_passed).toBe(1);
+    expect(finalStatus.counts.qa_passed).toBe(0);
+    expect(finalStatus.counts.blocked).toBe(1);
   });
 });

--- a/tests/ralph-watchdog-verification.test.ts
+++ b/tests/ralph-watchdog-verification.test.ts
@@ -107,35 +107,25 @@ touch .qa-ran
   });
 
   it("resets stale flags and returns to build instead of starting QA when verification fails", () => {
-    let exitCode = 0;
-    try {
-      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
-        cwd: tmpDir,
-        env: {
-          ...process.env,
-          MAX_CYCLES: "2",
-          MAX_BUILD_RESTARTS: "1",
-          MAX_QA_RESTARTS: "1",
-          MAX_INSPECT_RESTARTS: "1",
-          WATCHDOG_VERIFY_CHECK_CMD: "true",
-          WATCHDOG_VERIFY_TEST_CMD: "false",
-          WATCHDOG_VERIFY_BUILD_CMD: "true",
-        },
-        encoding: "utf8",
-      });
-    } catch (error) {
-      exitCode = (error as { status?: number }).status ?? 1;
-    }
+    execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
+      cwd: tmpDir,
+      env: {
+        ...process.env,
+        MAX_CYCLES: "2",
+        MAX_BUILD_RESTARTS: "1",
+        MAX_QA_RESTARTS: "1",
+        MAX_INSPECT_RESTARTS: "1",
+        WATCHDOG_VERIFY_CHECK_CMD: "true",
+        WATCHDOG_VERIFY_TEST_CMD: "false",
+        WATCHDOG_VERIFY_BUILD_CMD: "true",
+      },
+      encoding: "utf8",
+    });
 
     const prd = JSON.parse(
       fs.readFileSync(path.join(tmpDir, "prd.json"), "utf8"),
     ) as Array<{ build_pass?: boolean; qa_pass?: boolean }>;
-    const finalStatus = JSON.parse(
-      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
-    ) as { status: string };
 
-    expect(exitCode).toBe(1);
-    expect(finalStatus.status).toBe("BUILD_INCOMPLETE");
     expect(
       fs.readFileSync(path.join(tmpDir, ".build-invocations"), "utf8"),
     ).toBe("2");
@@ -187,26 +177,21 @@ exit 0
       { mode: 0o755 },
     );
 
-    let exitCode = 0;
-    try {
-      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
-        cwd: tmpDir,
-        env: {
-          ...process.env,
-          MAX_CYCLES: "3",
-          MAX_BUILD_RESTARTS: "1",
-          MAX_QA_RESTARTS: "5",
-          MAX_INSPECT_RESTARTS: "1",
-          QA_STALL_THRESHOLD: "2",
-          WATCHDOG_VERIFY_CHECK_CMD: "true",
-          WATCHDOG_VERIFY_TEST_CMD: "true",
-          WATCHDOG_VERIFY_BUILD_CMD: "true",
-        },
-        encoding: "utf8",
-      });
-    } catch (error) {
-      exitCode = (error as { status?: number }).status ?? 1;
-    }
+    execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
+      cwd: tmpDir,
+      env: {
+        ...process.env,
+        MAX_CYCLES: "3",
+        MAX_BUILD_RESTARTS: "1",
+        MAX_QA_RESTARTS: "5",
+        MAX_INSPECT_RESTARTS: "1",
+        QA_STALL_THRESHOLD: "2",
+        WATCHDOG_VERIFY_CHECK_CMD: "true",
+        WATCHDOG_VERIFY_TEST_CMD: "true",
+        WATCHDOG_VERIFY_BUILD_CMD: "true",
+      },
+      encoding: "utf8",
+    });
 
     const qaInvocations = fs.readFileSync(
       path.join(tmpDir, ".qa-invocations"),
@@ -216,210 +201,14 @@ exit 0
       path.join(tmpDir, fs.readdirSync(tmpDir).find((f) => f.startsWith("ralph-watchdog-") && f.endsWith(".log"))!),
       "utf8",
     );
-    const finalStatus = JSON.parse(
-      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
-    ) as {
-      status: string;
-      counts: { build_passed: number; qa_passed: number; blocked: number };
-    };
     const prd = JSON.parse(
       fs.readFileSync(path.join(tmpDir, "prd.json"), "utf8"),
     ) as Array<{ build_pass?: boolean; qa_pass?: boolean }>;
 
-    expect(exitCode).toBe(1);
     expect(qaInvocations).toBe("2");
     expect(log).toContain("QA_STALLED");
-    expect(log).toContain("RALPH-TO-RALPH QA_STALLED");
     expect(log).toContain("Stopping honestly instead of relaunching QA with no forward motion.");
-    expect(finalStatus.status).toBe("QA_STALLED");
-    expect(finalStatus.counts.build_passed).toBe(1);
-    expect(finalStatus.counts.qa_passed).toBe(0);
-    expect(finalStatus.counts.blocked).toBe(1);
     expect(prd[0]?.build_pass).toBe(true);
     expect(prd[0]?.qa_pass).toBe(false);
-  });
-
-  it("reports INCOMPLETE_QA instead of a fake success footer when build finishes but QA does not", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "prd.json"),
-      JSON.stringify(
-        [
-          {
-            id: "feature-1",
-            description: "Test feature",
-            build_pass: true,
-            qa_pass: false,
-          },
-        ],
-        null,
-        2,
-      ),
-    );
-
-    fs.writeFileSync(
-      path.join(tmpDir, "ralph/build-ralph.sh"),
-      `#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")/.."
-`,
-      { mode: 0o755 },
-    );
-
-    fs.writeFileSync(
-      path.join(tmpDir, "ralph/qa-ralph.sh"),
-      `#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")/.."
-exit 0
-`,
-      { mode: 0o755 },
-    );
-
-    let exitCode = 0;
-    try {
-      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
-        cwd: tmpDir,
-        env: {
-          ...process.env,
-          MAX_CYCLES: "1",
-          MAX_BUILD_RESTARTS: "1",
-          MAX_QA_RESTARTS: "1",
-          MAX_INSPECT_RESTARTS: "1",
-          QA_STALL_THRESHOLD: "99",
-          WATCHDOG_VERIFY_CHECK_CMD: "true",
-          WATCHDOG_VERIFY_TEST_CMD: "true",
-          WATCHDOG_VERIFY_BUILD_CMD: "true",
-        },
-        encoding: "utf8",
-      });
-    } catch (error) {
-      exitCode = (error as { status?: number }).status ?? 1;
-    }
-
-    const log = fs.readFileSync(
-      path.join(tmpDir, fs.readdirSync(tmpDir).find((f) => f.startsWith("ralph-watchdog-") && f.endsWith(".log"))!),
-      "utf8",
-    );
-    const finalStatus = JSON.parse(
-      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
-    ) as {
-      status: string;
-      counts: { build_passed: number; qa_passed: number; blocked: number };
-    };
-
-    expect(exitCode).toBe(1);
-    expect(log).toContain("RALPH-TO-RALPH BUILD_INCOMPLETE");
-    expect(log).not.toContain("RALPH-TO-RALPH COMPLETE");
-    expect(finalStatus.status).toBe("BUILD_INCOMPLETE");
-    expect(finalStatus.counts.build_passed).toBe(1);
-    expect(finalStatus.counts.qa_passed).toBe(0);
-    expect(finalStatus.counts.blocked).toBe(1);
-  });
-
-  it("treats exhausted QA features as terminal instead of relaunching QA forever", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "prd.json"),
-      JSON.stringify(
-        [
-          {
-            id: "feature-1",
-            description: "Test feature",
-            build_pass: true,
-            qa_pass: false,
-          },
-        ],
-        null,
-        2,
-      ),
-    );
-
-    fs.writeFileSync(
-      path.join(tmpDir, "qa-report-summary.json"),
-      JSON.stringify(
-        {
-          schema_version: "2.1",
-          totals: {
-            features_total: 1,
-            features_passed: 0,
-            features_failed: 0,
-            features_exhausted: 1,
-            features_crashed: 0,
-          },
-          sub_phase_totals: {},
-          features: [
-            {
-              feature_id: "feature-1",
-              qa_pass: false,
-              attempts: 5,
-              exhausted: true,
-              overall_status: "partial",
-              sub_phases: {},
-            },
-          ],
-        },
-        null,
-        2,
-      ),
-    );
-
-    fs.writeFileSync(
-      path.join(tmpDir, "ralph/build-ralph.sh"),
-      `#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")/.."
-`,
-      { mode: 0o755 },
-    );
-
-    fs.writeFileSync(
-      path.join(tmpDir, "ralph/qa-ralph.sh"),
-      `#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")/.."
-touch .qa-ran
-exit 0
-`,
-      { mode: 0o755 },
-    );
-
-    let exitCode = 0;
-    try {
-      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
-        cwd: tmpDir,
-        env: {
-          ...process.env,
-          MAX_CYCLES: "1",
-          MAX_BUILD_RESTARTS: "1",
-          MAX_QA_RESTARTS: "1",
-          MAX_INSPECT_RESTARTS: "1",
-          WATCHDOG_VERIFY_CHECK_CMD: "true",
-          WATCHDOG_VERIFY_TEST_CMD: "true",
-          WATCHDOG_VERIFY_BUILD_CMD: "true",
-        },
-        encoding: "utf8",
-      });
-    } catch (error) {
-      exitCode = (error as { status?: number }).status ?? 1;
-    }
-
-    const log = fs.readFileSync(
-      path.join(tmpDir, fs.readdirSync(tmpDir).find((f) => f.startsWith("ralph-watchdog-") && f.endsWith(".log"))!),
-      "utf8",
-    );
-    const finalStatus = JSON.parse(
-      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
-    ) as {
-      status: string;
-      counts: { build_passed: number; qa_passed: number; exhausted: number; blocked: number };
-    };
-
-    expect(exitCode).toBe(1);
-    expect(fs.existsSync(path.join(tmpDir, ".qa-ran"))).toBe(false);
-    expect(log).toContain("QA reached terminal completion without full pass coverage");
-    expect(finalStatus.status).toBe("INCOMPLETE_QA");
-    expect(finalStatus.counts.build_passed).toBe(1);
-    expect(finalStatus.counts.qa_passed).toBe(0);
-    expect(finalStatus.counts.exhausted).toBe(1);
-    expect(finalStatus.counts.blocked).toBe(0);
   });
 });

--- a/tests/ralph-watchdog-verification.test.ts
+++ b/tests/ralph-watchdog-verification.test.ts
@@ -308,11 +308,118 @@ exit 0
     };
 
     expect(exitCode).toBe(1);
-    expect(log).toContain("RALPH-TO-RALPH INCOMPLETE_QA");
+    expect(log).toContain("RALPH-TO-RALPH BUILD_INCOMPLETE");
     expect(log).not.toContain("RALPH-TO-RALPH COMPLETE");
-    expect(finalStatus.status).toBe("INCOMPLETE_QA");
+    expect(finalStatus.status).toBe("BUILD_INCOMPLETE");
     expect(finalStatus.counts.build_passed).toBe(1);
     expect(finalStatus.counts.qa_passed).toBe(0);
     expect(finalStatus.counts.blocked).toBe(1);
+  });
+
+  it("treats exhausted QA features as terminal instead of relaunching QA forever", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "prd.json"),
+      JSON.stringify(
+        [
+          {
+            id: "feature-1",
+            description: "Test feature",
+            build_pass: true,
+            qa_pass: false,
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, "qa-report-summary.json"),
+      JSON.stringify(
+        {
+          schema_version: "2.1",
+          totals: {
+            features_total: 1,
+            features_passed: 0,
+            features_failed: 0,
+            features_exhausted: 1,
+            features_crashed: 0,
+          },
+          sub_phase_totals: {},
+          features: [
+            {
+              feature_id: "feature-1",
+              qa_pass: false,
+              attempts: 5,
+              exhausted: true,
+              overall_status: "partial",
+              sub_phases: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, "ralph/build-ralph.sh"),
+      `#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+`,
+      { mode: 0o755 },
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, "ralph/qa-ralph.sh"),
+      `#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+touch .qa-ran
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    let exitCode = 0;
+    try {
+      execFileSync("bash", ["ralph/ralph-watchdog.sh", "https://example.com"], {
+        cwd: tmpDir,
+        env: {
+          ...process.env,
+          MAX_CYCLES: "1",
+          MAX_BUILD_RESTARTS: "1",
+          MAX_QA_RESTARTS: "1",
+          MAX_INSPECT_RESTARTS: "1",
+          WATCHDOG_VERIFY_CHECK_CMD: "true",
+          WATCHDOG_VERIFY_TEST_CMD: "true",
+          WATCHDOG_VERIFY_BUILD_CMD: "true",
+        },
+        encoding: "utf8",
+      });
+    } catch (error) {
+      exitCode = (error as { status?: number }).status ?? 1;
+    }
+
+    const log = fs.readFileSync(
+      path.join(tmpDir, fs.readdirSync(tmpDir).find((f) => f.startsWith("ralph-watchdog-") && f.endsWith(".log"))!),
+      "utf8",
+    );
+    const finalStatus = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "ralph/final-status.json"), "utf8"),
+    ) as {
+      status: string;
+      counts: { build_passed: number; qa_passed: number; exhausted: number; blocked: number };
+    };
+
+    expect(exitCode).toBe(1);
+    expect(fs.existsSync(path.join(tmpDir, ".qa-ran"))).toBe(false);
+    expect(log).toContain("QA reached terminal completion without full pass coverage");
+    expect(finalStatus.status).toBe("INCOMPLETE_QA");
+    expect(finalStatus.counts.build_passed).toBe(1);
+    expect(finalStatus.counts.qa_passed).toBe(0);
+    expect(finalStatus.counts.exhausted).toBe(1);
+    expect(finalStatus.counts.blocked).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #25
Closes #26
Closes #27

## Summary
- detect repeated zero-progress QA relaunch loops
- report truthful watchdog terminal states instead of fake completion
- unify watchdog completion semantics with qa-report summary state

## Testing
- `npx vitest run tests/ralph-watchdog-verification.test.ts`