### PR TITLE
chore: restore repo test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ralph-to-ralph",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "validate": "node scripts/validate-schemas.mjs"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "vitest": "^2.1.9"
+  }
+}


### PR DESCRIPTION
## Summary\n- add a repo-level package.json for Vitest and schema validation scripts\n- make npm test / npm run validate work for pipeline regression tests without relying on generated app setup\n\n## Verification\n- npm test -- --run tests/harden-watchdog.test.ts\n- npm run validate