### PR TITLE
test: set watchdog-friendly default timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run",
+    "test": "vitest run --testTimeout=45000",
     "test:watch": "vitest",
     "validate": "node scripts/validate-schemas.mjs"
   },


### PR DESCRIPTION
## Summary\n- make npm test run the full Vitest suite with a timeout high enough for watchdog integration cases\n- removes the need to remember per-command --testTimeout flags\n\n## Verification\n- npm test\n- npm run validate