### PR TITLE
docs: add Architect agent + refresh Build/QA rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,11 @@ ralph-to-ralph/
 |-------|--------------|-----------------|-------|
 | **Onboarding** (Claude) | `ralph/onboard-prompt.md`, `ralph/pre-setup.md`, `CLAUDE.md` | `ralph-config.json`, installed deps, rewritten config files | Pre-loop |
 | **Inspect** (Claude + Ever CLI) | `ralph/inspect-prompt.md`, `ralph/inspect-spec.md`, `ralph/ever-cli-reference.md` | `prd.json`, screenshots in `ralph/screenshots/inspect/` | Phase 1 |
-| **Build** (Claude) | `ralph/build-prompt.md`, `prd.json`, `CLAUDE.md` | Source code in `src/`, tests in `tests/`, SDK in `packages/sdk/` | Phase 2 |
-| **QA** (Codex + Ever CLI) | `AGENTS.md`, `ralph/qa-prompt.md`, `ralph/ever-cli-reference.md` | Bug fixes, QA screenshots in `ralph/screenshots/qa/` | Phase 3 |
+| **Architect** (Claude) | `ralph/architecture-prompt.md`, `prd.json`, `target-docs/`, `ralph-config.json` | `ralph/architecture-decisions.json`, updated `build-spec.md` | Phase 1.5 |
+| **Build** (Claude) | `ralph/build-prompt.md`, `ralph/structure-prompt.md`, `prd.json`, `build-spec.md`, `CLAUDE.md` | Source in `src/`, tests in `tests/`, SDK in `packages/sdk/`, structure outlines in `.qrspi/{feature-id}/structure.md` (when needed) | Phase 2 (+2.5 Structure inline) |
+| **QA** (Codex + Ever CLI, multi-layer) | `AGENTS.md`, `ralph/qa/{base,api,security,a11y,footer}.md`, `ralph/ever-cli-reference.md` | Bug fixes, QA screenshots in `ralph/screenshots/qa/`, `qa-report.json` | Phase 3 |
+
+The QA agent uses **progressive disclosure** — `qa-ralph.sh` assembles the prompt from the modules above based on feature category (auth, crud, infrastructure, settings, etc.). Not every feature runs all four sub-phases.
 
 ### What Gets Built
 


### PR DESCRIPTION
## Summary
- Agent Roles table was missing Phase 1.5 (Architect) and referenced \`ralph/qa-prompt.md\`, which was replaced by \`ralph/qa/*.md\` modules a while back.
- Add the missing row, refresh the Build and QA rows, add a one-sentence callout for QA progressive disclosure.

## Changes
- **New row:** \`Architect\` (Phase 1.5) — reads architecture-prompt.md + PRD, produces architecture-decisions.json
- **Build row:** now lists \`structure-prompt.md\` + \`build-spec.md\` as inputs and \`.qrspi/{feature-id}/structure.md\` as an output (Phase 2.5 Structure runs inline inside Build per \`build-prompt.md:34-45\`)
- **QA row:** input file changed from non-existent \`qa-prompt.md\` to the real \`ralph/qa/{base,api,security,a11y,footer}.md\`; agent label updated to "multi-layer"; \`qa-report.json\` added to outputs
- **New paragraph** under the table explaining progressive disclosure (qa-ralph.sh assembles the prompt from modules per feature category)

## Test plan
- [ ] Visual check the table still renders cleanly on GitHub
- [ ] All file paths in the table actually exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)