### PR TITLE
docs: add make validate + granular targets to Commands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,14 +293,18 @@ ralph-to-ralph/
 
 | Command | What It Does |
 |---------|-------------|
-| `make check` | Typecheck + lint/format (stack-specific) |
+| `make check` | Typecheck + lint/format (composite) |
 | `make test` | Run unit tests |
 | `make test-e2e` | Run E2E tests (needs dev server) |
 | `make all` | `check` + `test` |
 | `make fix` | Auto-fix lint/format issues |
+| `make validate` | Validate state files (`prd.json`, `qa-report.json`, `ralph-config.json`, `ralph/ralph-state.json`) against their JSON schemas |
 | `make dev` | Dev server on port **3015** |
 | `make build` | Production build |
-| `make db-push` | Push schema to database |
+| `make db-push` / `db-generate` / `db-migrate` | Schema sync · generate migration · run migrations |
+| `make typecheck` / `lint` / `format` / `clean` | Granular targets — usually run via `make check` |
+
+Pass `VERBOSE=1` (or use `make check-verbose` / `test-verbose`) to see full output instead of the silent-on-success summary.
 
 ### Agent Roles
 


### PR DESCRIPTION
## Summary
- Commands table was missing real Makefile targets: \`make validate\`, granular composites (\`typecheck\`/\`lint\`/\`format\`/\`clean\`), DB ops (\`db-generate\`/\`db-migrate\`), and verbose variants.
- Surface them without bloating the table — collapsed related targets into one row each, plus a tail sentence on verbose mode.

## Changes
- New row: \`make validate\` (validates the four state files against their JSON schemas)
- Collapsed row: \`db-push\` / \`db-generate\` / \`db-migrate\`
- Collapsed row: \`typecheck\` / \`lint\` / \`format\` / \`clean\` (granular escape hatches)
- Tail sentence on \`VERBOSE=1\` / \`check-verbose\` / \`test-verbose\`

## Test plan
- [ ] Every command in the table is a real \`Makefile\` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)