### PR TITLE
docs: fix upstream remote URL to namuh-eng

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ git clone https://github.com/YOUR_USERNAME/ralph-to-ralph.git
 cd ralph-to-ralph
 
 # Optional: track upstream for future pipeline improvements
-git remote add upstream https://github.com/jaeyunha/ralph-to-ralph.git
+git remote add upstream https://github.com/namuh-eng/ralph-to-ralph.git
 ```
 
 Then continue:


### PR DESCRIPTION
## Summary
Step 1's upstream remote pointed at \`github.com/jaeyunha/ralph-to-ralph\` but the canonical repo is \`github.com/namuh-eng/ralph-to-ralph\` (used at \`README.md:191\`, \`:194\`, \`:408-413\`). Following the README literally would set up an upstream that's stale.

## Changes
- One-line fix: \`jaeyunha\` → \`namuh-eng\` in the suggested \`git remote add upstream\` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)