### PR TITLE
docs: lead change-target-product with onboarding skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,14 @@ The pipeline produces a **fully functional, deployed product** — not a mockup.
 
 ### Changing the target product
 
-Re-run onboarding:
+Re-run onboarding. Easiest in your coding agent:
+
+| Agent | Invoke with |
+|-------|-------------|
+| Claude Code | `/ralph-to-ralph-onboard` |
+| Codex | `$ralph-to-ralph-onboard` |
+
+For a clean slate (clears `ralph-config.json` and `.ralph-setup-done`), use the script form:
 
 ```bash
 ./ralph/onboard.sh --reset   # Clear previous config


### PR DESCRIPTION
## Summary
- Show \`/ralph-to-ralph-onboard\` (Claude Code) and \`\$ralph-to-ralph-onboard\` (Codex) as the primary path
- Keep \`./ralph/onboard.sh --reset\` as the clean-slate alternative

Matches the skill-first pattern from #50.

## Test plan
- [ ] README renders with the agent table
- [ ] Both invocation strings match the onboard skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)