### PR TITLE
docs: clarify resume behavior for skill vs script onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,9 @@ Yes. The default personal path is Vercel + Neon, and you can also choose AWS, GC
 <details>
 <summary><strong>Can I resume interrupted onboarding?</strong></summary>
 
-Yes. If you interrupt `onboard.sh` (Ctrl+C), your answers are saved to `.onboard-answers.tmp`. Re-run `./ralph/onboard.sh` and it will offer to resume. Use `./ralph/onboard.sh --reset` to start completely fresh.
+**Skill (`/ralph-to-ralph-onboard`)** — answers live in the agent's session. Continue the same chat to resume where you left off. If you start a new session, just re-run the skill: it gathers answers in memory and only writes `ralph-config.json` at the final phase, so an interrupted run leaves nothing to clean up.
+
+**Script (`./ralph/onboard.sh`)** — answers are saved to `.onboard-answers.tmp` on Ctrl+C. Re-run the script and it will offer to resume. Use `./ralph/onboard.sh --reset` to start completely fresh.
 </details>
 
 ---


### PR DESCRIPTION
## Summary
- Skill flow: answers live in the agent session; \`ralph-config.json\` is only written at the final phase, so interruption leaves nothing to clean up
- Script flow: \`.onboard-answers.tmp\` save-on-Ctrl+C and \`--reset\` for clean slate (unchanged)

Previously the FAQ only described the script path, which was misleading after the skill became the recommended entry point.

## Test plan
- [ ] FAQ entry renders both paths
- [ ] Skill behavior matches \`SKILL.md\` Phase 7 write semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)