### PR TITLE
fix: stop telling users the build loop needs ANTHROPIC_API_KEY

### DIFF
--- a/.claude/skills/ralph-to-ralph-onboard/SKILL.md
+++ b/.claude/skills/ralph-to-ralph-onboard/SKILL.md
@@ -244,7 +244,7 @@ Run verification commands for each service they claimed is ready. Only check wha
 | GCP CLI | `gcloud auth print-identity-token` | Returns a token |
 | Azure CLI | `az account show` | Returns subscription JSON |
 | Neon | Check `.env` for `DATABASE_URL` containing `neon.tech` | Key exists and is non-empty |
-| Anthropic API key | Check `.env` for `ANTHROPIC_API_KEY` | Key exists and is non-empty |
+| Anthropic API key (only if clone calls Claude at runtime) | Check `.env` for `ANTHROPIC_API_KEY` | Key exists and is non-empty |
 | Cloudflare | Check `.env` for `CLOUDFLARE_API_TOKEN` | Key exists and is non-empty |
 | Ever CLI | `ever --version` | Returns a version |
 | Docker | `docker info` | Daemon is running |
@@ -304,7 +304,6 @@ Verifying your setup...
   ✓ Node.js — v22.1.0
   ✓ Vercel CLI — logged in as ashley
   ✓ Neon — DATABASE_URL found in .env
-  ✗ Anthropic API key — ANTHROPIC_API_KEY not found in .env
   ✓ Ever CLI — v1.2.0
 ```
 
@@ -312,8 +311,10 @@ Verifying your setup...
 
 For each failed check, provide a **one-line fix** immediately:
 
-> `✗ Anthropic API key — not found in .env`
+> `✗ Anthropic API key — not found in .env` (only required if your clone calls Claude at runtime — not for the build loop)
 > Fix: Add `ANTHROPIC_API_KEY=sk-ant-...` to your `.env` file. Get a key at console.anthropic.com.
+
+**Note for the agent:** Do NOT tell the user the build loop needs `ANTHROPIC_API_KEY`. The watchdog calls the `claude` CLI in headless mode (`claude -p ...`), which authenticates via the user's Claude Code login/subscription, not via this env var. `ANTHROPIC_API_KEY` is only needed when the *cloned product itself* makes Anthropic API calls at runtime (e.g., the target product has AI features).
 
 Then ask: **"Want to fix these now, or continue and handle them later?"**
 


### PR DESCRIPTION
## Summary

The onboarding skill was telling users that \`ANTHROPIC_API_KEY\` is required because "the build loop runs Claude headless." That justification is fabricated.

\`ralph-watchdog.sh:575\`, \`build-ralph.sh:157,190\`, and \`inspect-ralph.sh:139\` all invoke \`claude -p --dangerously-skip-permissions ...\` — the **Claude Code CLI in headless mode**, which authenticates via the user's Claude Code login/subscription. \`ANTHROPIC_API_KEY\` is **not** consumed by the build loop.

\`onboard-prompt.md:242\` already correctly labels the check \`DEFERRABLE — only needed if clone has AI features\`. The skill flattened that into a default requirement and invented a reason.

## Changes (\`SKILL.md\`)

- Verification row now reads \"Anthropic API key (only if clone calls Claude at runtime)\"
- Dropped the failed ANTHROPIC_API_KEY line from the default verification output
- Annotated the failure fix-message: \"only required if your clone calls Claude at runtime — not for the build loop\"
- Added an explicit \"Note for the agent\" warning against repeating the fabricated build-loop justification

## Verification

- \`grep -n \"claude -p\" ralph/*.sh\` confirms headless CLI usage everywhere
- \`onboard-prompt.md:232,242,248-250\` already treat the key as deferrable / runtime-only

## Test plan

- [ ] Re-run \`/ralph-to-ralph-onboard\` on a target with no AI features and confirm it does not flag ANTHROPIC_API_KEY
- [ ] Re-run on a target with AI features and confirm the conditional check still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)