### PR TITLE
docs: add Azure to Cloud CLI table; note Railway/Fly via custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Pick one and authenticate it. Onboarding will ask if it doesn't find one already
 | **Vercel** (default, personal) | `npm install -g vercel` | `vercel login` |
 | **AWS** (team / production) | `brew install awscli` | `aws configure` |
 | **GCP** | [Install gcloud](https://cloud.google.com/sdk/docs/install) | `gcloud auth login` |
+| **Azure** | [Install az](https://learn.microsoft.com/cli/azure/install-azure-cli) | `az login` |
+
+Want **Railway**, **Fly.io**, **Render**, or self-hosted? Pick "custom" during onboarding and describe your stack — onboarding generates a stack-specific preflight script.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add **Azure** row (\`az login\`) — already a first-class option in \`onboard.sh\` but missing from the README
- One-line pointer for **Railway / Fly.io / Render / self-hosted** via the \"custom\" provider path (\`onboard-prompt.md:438-441\` already handles these)

## Test plan
- [ ] README renders with the new row
- [ ] Custom-stack pointer matches what \`onboard.sh\` actually accepts (Railway+Neon, Fly+Supabase, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)