### PR TITLE
docs: rewrite Skipping phases section to include inspect + watchdog warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,14 +371,17 @@ The pipeline is controlled by prompt files:
 | `ralph/qa/{base,api,security,a11y,footer}.md` | How the QA agent tests features — modules assembled per feature category |
 | `ralph/pre-setup.md` | Pre-configured setup context (read by all agents) |
 
-### Skipping phases
+### Running phases individually
 
-If you already have a `prd.json`, run phases individually:
+The watchdog (`ralph/ralph-watchdog.sh`) is the production entry point — it handles process-level restarts, cost caps, build-proof gating before QA, and stall detection. Run a single phase only when iterating manually:
 
 ```bash
-./ralph/build-ralph.sh    # Phase 2 only
-./ralph/qa-ralph.sh       # Phase 3 only
+./ralph/inspect-ralph.sh <target-url>   # Phase 1 only — generate / refresh prd.json
+./ralph/build-ralph.sh                  # Phase 2 only — needs prd.json
+./ralph/qa-ralph.sh                     # Phase 3 only — needs a built clone
 ```
+
+These scripts have **no process-level restart logic** — if they crash, they stay crashed. Fine for short sessions; for unattended end-to-end runs, always use the watchdog.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add \`./ralph/inspect-ralph.sh <target-url>\` to the list (was missing)
- Reframe as \"Running phases individually\" instead of \"Skipping phases\"
- Honest note: per-phase scripts have no process-level restart, cost cap, or build-proof gate — the watchdog is the production entry point

## Why
The previous wording suggested any phase could be cleanly skipped, but the watchdog provides crash-restart, budget enforcement, and stall detection that the bare scripts don't. Users running \`./ralph/build-ralph.sh\` standalone need to know they're trading reliability for control.

## Test plan
- [ ] All three script names match what's actually in \`ralph/\`
- [ ] Argument signatures match (\`inspect-ralph.sh <target-url>\`, others optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)