### PR TITLE
docs: move star ask into onboarding flow, drop awkward Setup Step 4

### DIFF
--- a/.claude/skills/ralph-to-ralph-onboard/SKILL.md
+++ b/.claude/skills/ralph-to-ralph-onboard/SKILL.md
@@ -442,6 +442,14 @@ If the script fails, show the error to the user and stop — do not proceed to t
 
 **Step 7c — Rewrite prompts and finish.** Follow `@references/onboard-prompt.md` starting from **Step 6** (Rewrite inspect-prompt.md) — Steps 3–5 have already been handled above.
 
+**Star prompt (optional, gated).** Before launching the build loop, ask the user once if they'd like to star the repo. Only ask if `gh` is installed and `gh auth status` succeeds — otherwise skip silently. Use `AskUserQuestion` with default "No". On yes, run:
+
+```bash
+gh api --method PUT /user/starred/namuh-eng/ralph-to-ralph --silent
+```
+
+Never block on this — if the call fails or `gh` isn't available, proceed straight to the build loop. This mirrors `onboard.sh`'s `maybe_prompt_to_star_repo`.
+
 When done, launch the build loop:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -185,16 +185,6 @@ test -f .ralph-setup-done && echo "Stack: $(cat .ralph-setup-done)"
 make check && make test
 ```
 
-### Step 4: Star this repo
-
-If Ralph-to-Ralph saved you time, a star helps others find it:
-
-```bash
-gh repo star namuh-eng/ralph-to-ralph
-```
-
-Or open in your browser: **https://github.com/namuh-eng/ralph-to-ralph**
-
 ---
 
 ## Architecture Reference


### PR DESCRIPTION
## Summary
- Delete \"Step 4: Star this repo\" from README's Setup section — it interrupted the user mid-setup
- Add a gated star prompt to \`SKILL.md\` Step 7c, mirroring \`onboard.sh:980\`'s \`maybe_prompt_to_star_repo\`

## Why
The script path already asks at the moment of success. The skill path didn't ask at all. The README asked at the wrong time. Now both onboarding paths ask once at success, and the README focuses on getting users running.

## Test plan
- [ ] README Setup ends cleanly at Step 3
- [ ] Skill prompt only fires when \`gh\` is authenticated; skips silently otherwise
- [ ] Star ask is non-blocking (failure goes straight to build loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)