### PR TITLE
docs: fix stale phase count — four phases, not five

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The clone sends real emails via AWS SES, verifies real domains, auto-configures 
 
 ## How It Works
 
-A single watchdog orchestrator (`ralph/ralph-watchdog.sh`) drives five phases. It auto-restarts failures, tracks token cost against a budget cap, refuses to enter QA until the workspace proves it builds, and detects zero-progress QA stalls. Up to 5 build-QA cycles per feature.
+A single watchdog orchestrator (`ralph/ralph-watchdog.sh`) drives four phases. It auto-restarts failures, tracks token cost against a budget cap, refuses to enter QA until the workspace proves it builds, and detects zero-progress QA stalls. Up to 5 build-QA cycles per feature.
 
 | Phase | Agent | What It Does |
 |-------|-------|-------------|


### PR DESCRIPTION
## Summary
- Change \"drives five phases\" to \"drives four phases\" in the How It Works opener
- Phases: Inspect (1), Architecture (1.5), Build (2), QA (3) — verified against \`ralph-watchdog.sh\` (\`PHASE 1\`, \`PHASE 1.5\`, \`PHASE 2\`)
- Phase 2.5 (Structure) is inline within Build, not a top-level orchestrated phase
- Harden loop removal (#51) made the original \"five\" stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)