### PR TITLE
docs: add Stack section showing the three first-class templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ Want **Railway**, **Fly.io**, **Render**, or self-hosted? Pick "custom" during o
 
 ---
 
+## Stack
+
+Onboarding picks one of three first-class stacks based on your answers (language + framework), writes the choice to `ralph-config.json`, and runs the matching template's setup script.
+
+| Stack | Language | Framework | Tests | Linter |
+|-------|----------|-----------|-------|--------|
+| **typescript-nextjs** (default, most complete) | TypeScript | Next.js + React + Tailwind | Vitest + Playwright | Biome |
+| **python-fastapi** | Python | FastAPI + uvicorn | pytest + httpx | Ruff |
+| **go-chi** | Go | chi router | `go test` | `go test` (no separate linter) |
+
+The TypeScript template ships the most pre-wired tooling — Drizzle for DB, Playwright for E2E, full `make test-e2e` and `make db-push` targets. Python and Go templates are minimal scaffolds; the build agent installs database drivers and feature-specific dependencies as the PRD requires them.
+
+After onboarding, `.ralph-setup-done` records the template name and `BUILD_GUIDE.md` (in the repo root) has stack-specific build instructions. Templates live in `.claude/skills/ralph-to-ralph-onboard/templates/`.
+
+---
+
 ## Setup
 
 Follow these steps in order. Each step has a verification command — run it before moving to the next step.


### PR DESCRIPTION
## Summary
- New \`## Stack\` section between Prerequisites and Setup
- Comparison table: typescript-nextjs (default), python-fastapi, go-chi
- Honest about what each template ships (TS is most complete; Python/Go are minimal scaffolds the build agent extends)

## Why
Python and Go templates were only mentioned in the file map. Readers couldn't see the choice exists or know what trade-offs it implies before they start.

## Verification
Ran the file listings against the templates directory and per-stack \`makefile-targets.mk\`:
- TS: biome, drizzle-kit (db-push/migrate/generate), playwright (test-e2e), vitest, tailwind
- Python: fastapi/uvicorn, pytest+httpx, ruff (no DB tooling, no e2e in template)
- Go: chi router only, \`go test\` (no separate linter, no DB tooling, no e2e in template)

Table reflects reality, not aspiration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)