### PR TITLE
fix(inspect): prefer uv venv to survive shimmed python3

### DIFF
--- a/ralph/inspect-ralph.sh
+++ b/ralph/inspect-ralph.sh
@@ -59,13 +59,22 @@ if [ "$_coverage_passed" -eq 0 ]; then
       rm -rf .venv-scrape
     fi
     echo "First-time setup: creating .venv-scrape and installing scrape-docs deps..."
-    if ! command -v python3 >/dev/null 2>&1; then
-      echo "ERROR: python3 is required for the doc scraper. Install Python 3.10+ and re-run." >&2
+    # Prefer `uv venv` so this works on machines where `python3` is a shim
+    # that refuses `-m venv` (uv-managed pyenv, asdf strict mode, etc.).
+    # Fall back to bare `python3 -m venv` for systems without uv.
+    if command -v uv >/dev/null 2>&1; then
+      uv venv .venv-scrape >/dev/null
+      .venv-scrape/bin/python -m ensurepip --upgrade >/dev/null 2>&1 || true
+      .venv-scrape/bin/python -m pip install --quiet --upgrade pip
+      .venv-scrape/bin/python -m pip install --quiet -r scripts/scrape-docs-requirements.txt
+    elif command -v python3 >/dev/null 2>&1; then
+      python3 -m venv .venv-scrape
+      .venv-scrape/bin/pip install --quiet --upgrade pip
+      .venv-scrape/bin/pip install --quiet -r scripts/scrape-docs-requirements.txt
+    else
+      echo "ERROR: doc scraper needs either uv or python3 (3.10+). Install one and re-run." >&2
       exit 1
     fi
-    python3 -m venv .venv-scrape
-    .venv-scrape/bin/pip install --quiet --upgrade pip
-    .venv-scrape/bin/pip install --quiet -r scripts/scrape-docs-requirements.txt
     # Pre-fetch browser binaries so StealthyFetcher / PlayWrightFetcher don't
     # silently degrade to plain HTTP on Cloudflare-protected or SPA-rendered
     # doc sites. Both installers are best-effort: if the download fails we


### PR DESCRIPTION
## Summary
- `ralph/inspect-ralph.sh` now prefers `uv venv` when available, falling back to `python3 -m venv` for systems without uv.
- Eliminates the silent inspect-loop death on machines where `python3` is a shim (uv-managed pyenv, asdf strict mode) that refuses `-m venv`.
- Error message when *both* uv and python3 are missing names both options.

## Why
Combined with #65 (watchdog masking exit codes), the shimmed-`python3` failure surfaced as `Hit max restarts (5). Aborting.` with no useful diagnostic. With #65 merged, real exit codes already propagate; this PR fixes the underlying bootstrap so most users won't trip the failure path at all.

## Test plan
- [x] `bash -n` passes.
- [x] Smoke test on this machine (uv 0.9.18 + python3 3.13): `uv venv .venv-scrape` succeeds, `ensurepip` + `pip install --upgrade pip` work, `bin/python` and `bin/pip` interface intact for downstream `pip install -r scrape-docs-requirements.txt`.
- [ ] Live verification on a fresh onboard run.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)