### PR TITLE
fix(scraper): make discovery ladder coverage-gate-aware

### DIFF
--- a/scripts/scrape-docs.py
+++ b/scripts/scrape-docs.py
@@ -853,47 +853,45 @@ def _delete_orphan_files(out_dir: Path, pages: list[FetchedPage]) -> None:
                 log(f"  warn: could not remove orphan {path}: {exc}")
 
 
+# Absolute minimum page count to retain a stage as a fallback candidate when
+# no later stage clears ``min_pages``. Below this we treat the stage as noise
+# (e.g. a docs-flavored 404 page or a stub index) and clean up.
+ABS_FLOOR = 5
+
+
 def _run_url_list_stage(
     name: str,
     urls: list[str],
     out_dir: Path,
     max_pages: int,
     concurrency: int,
-    min_pages: int,
-    result: ScrapeResult,
-) -> bool:
-    """Fetch a flat URL list, write pages, and decide whether to accept the
-    stage. Returns ``True`` if the stage met the page threshold (caller should
-    return). Returns ``False`` if the stage fell through; in that case the
-    orphan files have already been cleaned and ``result.pages`` /
-    ``result.failures`` are reset.
+) -> tuple[list[FetchedPage], list[tuple[str, str]]]:
+    """Fetch a flat URL list and write extracted pages to ``out_dir``.
+
+    Returns ``(pages, failures)``. The caller decides whether to accept the
+    stage (commit pages to ``result``) or roll it back via
+    ``_delete_orphan_files``. We deliberately don't mutate ``result`` here so
+    the discovery ladder can run multiple stages and pick the best one.
     """
     successes, failures = fetch_many(urls[:max_pages], concurrency)
-    result.failures.extend(failures)
     stage_pages: list[FetchedPage] = []
+    stage_failures: list[tuple[str, str]] = list(failures)
     for url, html, fetcher_name in successes:
         md = html_to_markdown(html, url)
         if not md:
-            result.failures.append((url, "trafilatura returned empty"))
+            stage_failures.append((url, "trafilatura returned empty"))
             continue
         if len(md) < MIN_MARKDOWN_CHARS:
-            result.failures.append((url, f"extracted markdown too short ({len(md)} chars)"))
+            stage_failures.append((url, f"extracted markdown too short ({len(md)} chars)"))
             continue
         try:
             page = write_page(out_dir, url, md, fetcher=fetcher_name)
         except ValueError as exc:
-            result.failures.append((url, f"write refused: {exc}"))
+            stage_failures.append((url, f"write refused: {exc}"))
             continue
         stage_pages.append(page)
-    result.pages.extend(stage_pages)
-    if len(result.pages) >= min(min_pages, 5):
-        result.discovery = name
-        return True
-    log(f"  {name} yielded only {len(result.pages)} pages, falling through")
-    _delete_orphan_files(out_dir, stage_pages)
-    result.pages.clear()
-    result.failures.clear()
-    return False
+    log(f"  {name} produced {len(stage_pages)} pages")
+    return stage_pages, stage_failures
 
 
 def run_pipeline(
@@ -965,29 +963,88 @@ def run_pipeline(
             result.discovery = "llms-full.txt"
             return result
 
+    # Discovery ladder: probe each stage in order. Accept the first that
+    # clears ``min_pages`` (the coverage gate). If none does, fall back to
+    # the largest stage that cleared ``ABS_FLOOR`` (handles tiny micro-products
+    # whose entire doc surface is < min_pages). Stages that don't clear
+    # ABS_FLOOR are cleaned up so the next stage starts with an empty out_dir.
+    #
+    # Why "best of" instead of "first match": some products publish a thin or
+    # misleading llms.txt (e.g. docs.github.com lists API endpoints, not docs).
+    # Accepting that on first match traps us below the coverage gate with no
+    # second chance. With "best of", a productive sitemap or crawl wins.
+    best_fallback: tuple[str, list[FetchedPage], list[tuple[str, str]]] | None = None
+
+    def commit(name: str, pages: list[FetchedPage], failures: list[tuple[str, str]]) -> None:
+        """Commit a stage as the winning discovery. Cleans any prior fallback's
+        files from disk first so we don't leave orphans alongside the winner.
+        """
+        nonlocal best_fallback
+        if best_fallback is not None:
+            _, fb_pages, _ = best_fallback
+            # Don't delete files the winner also produced (same URL, same path).
+            winner_paths = {p.rel_path for p in pages}
+            stale = [p for p in fb_pages if p.rel_path not in winner_paths]
+            _delete_orphan_files(out_dir, stale)
+            best_fallback = None
+        result.pages = list(pages)
+        result.failures.extend(failures)
+        result.discovery = name
+
+    def consider_fallback(
+        name: str, pages: list[FetchedPage], failures: list[tuple[str, str]]
+    ) -> None:
+        """Track the best below-threshold stage. Cleans the loser's files."""
+        nonlocal best_fallback
+        if len(pages) < ABS_FLOOR:
+            log(f"  {name} below floor ({len(pages)} < {ABS_FLOOR}), discarding")
+            _delete_orphan_files(out_dir, pages)
+            return
+        if best_fallback is None or len(pages) > len(best_fallback[1]):
+            if best_fallback is not None:
+                _, fb_pages, _ = best_fallback
+                # Don't delete files the new fallback also produced.
+                new_paths = {p.rel_path for p in pages}
+                stale = [p for p in fb_pages if p.rel_path not in new_paths]
+                _delete_orphan_files(out_dir, stale)
+            log(f"  {name} kept as fallback ({len(pages)} pages, below min_pages={min_pages})")
+            best_fallback = (name, pages, failures)
+        else:
+            log(f"  {name} discarded ({len(pages)} pages, fallback has {len(best_fallback[1])})")
+            _delete_orphan_files(out_dir, pages)
+
     # 2. llms.txt
     llms_urls = discover_llms_txt(base_url)
-    if llms_urls and len(llms_urls) >= 5:
-        if _run_url_list_stage(
-            "llms.txt", llms_urls, out_dir, max_pages, concurrency, min_pages, result
-        ):
+    if llms_urls and len(llms_urls) >= ABS_FLOOR:
+        pages, failures = _run_url_list_stage(
+            "llms.txt", llms_urls, out_dir, max_pages, concurrency
+        )
+        if len(pages) >= min_pages:
+            commit("llms.txt", pages, failures)
             return result
+        consider_fallback("llms.txt", pages, failures)
 
     # 3. mint.json
     mint_urls = discover_mint_json(base_url)
-    if mint_urls and len(mint_urls) >= 5:
-        if _run_url_list_stage(
-            "mint.json", mint_urls, out_dir, max_pages, concurrency, min_pages, result
-        ):
+    if mint_urls and len(mint_urls) >= ABS_FLOOR:
+        pages, failures = _run_url_list_stage(
+            "mint.json", mint_urls, out_dir, max_pages, concurrency
+        )
+        if len(pages) >= min_pages:
+            commit("mint.json", pages, failures)
             return result
+        consider_fallback("mint.json", pages, failures)
 
     # 4. sitemap.xml
     sitemap_urls = discover_sitemap(base_url)
-    if sitemap_urls and len(sitemap_urls) >= 5:
-        if _run_url_list_stage(
-            "sitemap.xml", sitemap_urls, out_dir, max_pages, concurrency, min_pages, result
-        ):
+    if sitemap_urls and len(sitemap_urls) >= ABS_FLOOR:
+        pages, failures = _run_url_list_stage(
+            "sitemap.xml", sitemap_urls, out_dir, max_pages, concurrency
+        )
+        if len(pages) >= min_pages:
+            commit("sitemap.xml", pages, failures)
             return result
+        consider_fallback("sitemap.xml", pages, failures)
 
     # 5. crawl
     seed_candidates = [
@@ -1006,27 +1063,39 @@ def run_pipeline(
         if not crawled:
             continue
         seed_pages: list[FetchedPage] = []
+        seed_failures: list[tuple[str, str]] = []
         for url, html, fetcher_name in crawled:
             md = html_to_markdown(html, url)
             if not md:
-                result.failures.append((url, "trafilatura returned empty"))
+                seed_failures.append((url, "trafilatura returned empty"))
                 continue
             if len(md) < MIN_MARKDOWN_CHARS:
-                result.failures.append((url, f"extracted markdown too short ({len(md)} chars)"))
+                seed_failures.append((url, f"extracted markdown too short ({len(md)} chars)"))
                 continue
             try:
                 page = write_page(out_dir, url, md, fetcher=fetcher_name)
             except ValueError as exc:
-                result.failures.append((url, f"write refused: {exc}"))
+                seed_failures.append((url, f"write refused: {exc}"))
                 continue
             seed_pages.append(page)
-        result.pages.extend(seed_pages)
-        if result.pages:
-            result.discovery = f"crawl({seed})"
+        if len(seed_pages) >= min_pages:
+            commit(f"crawl({seed})", seed_pages, seed_failures)
             return result
-        # Seed yielded crawled HTML but trafilatura extracted nothing usable —
-        # clean the empty/orphan files before trying the next seed.
-        _delete_orphan_files(out_dir, seed_pages)
+        if seed_pages:
+            consider_fallback(f"crawl({seed})", seed_pages, seed_failures)
+            # crawl already exhausted this seed; don't retry remaining seeds
+            # if it produced anything (matches prior behavior of breaking on
+            # first non-empty seed).
+            break
+
+    # No stage cleared the coverage gate. Use the best fallback if any so the
+    # caller sees the actual coverage shortfall instead of a falsely-empty run.
+    if best_fallback is not None:
+        name, pages, failures = best_fallback
+        result.pages = list(pages)
+        result.failures.extend(failures)
+        # Tag the discovery so coverage.json shows we fell back below the gate.
+        result.discovery = f"{name} (below min_pages)"
 
     return result
 

--- a/tests/test_scrape_docs_pipeline.py
+++ b/tests/test_scrape_docs_pipeline.py
@@ -1,0 +1,250 @@
+"""Regression test for scripts/scrape-docs.py discovery ladder.
+
+Covers issue #68: the scraper accepted thin llms.txt results without falling
+through to sitemap/crawl, causing real-world targets like docs.github.com to
+fail the coverage gate even though sitemap+crawl would have produced enough
+pages.
+
+Runs without pytest. Stubs heavy native deps (scrapling, trafilatura,
+defusedxml) before importing the scraper, then monkey-patches the discovery
+and fetch helpers to simulate stage outcomes deterministically.
+
+Run: python3 tests/test_scrape_docs_pipeline.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _stub_heavy_imports() -> None:
+    """scrape-docs imports scrapling/trafilatura/defusedxml at module load.
+    Stub them so the import succeeds in environments without .venv-scrape.
+    """
+    if "scrapling" not in sys.modules:
+        scrapling = types.ModuleType("scrapling")
+        fetchers = types.ModuleType("scrapling.fetchers")
+        for name in ("Fetcher", "StealthyFetcher", "PlayWrightFetcher"):
+            setattr(fetchers, name, type(name, (), {"get": staticmethod(lambda *a, **k: None)}))
+        scrapling.fetchers = fetchers
+        sys.modules["scrapling"] = scrapling
+        sys.modules["scrapling.fetchers"] = fetchers
+
+    if "trafilatura" not in sys.modules:
+        trafilatura = types.ModuleType("trafilatura")
+        trafilatura.extract = lambda *a, **k: None  # type: ignore
+        sys.modules["trafilatura"] = trafilatura
+
+    if "defusedxml" not in sys.modules:
+        defusedxml = types.ModuleType("defusedxml")
+        et = types.ModuleType("defusedxml.ElementTree")
+        et.fromstring = lambda *a, **k: None  # type: ignore
+        defusedxml.ElementTree = et
+        sys.modules["defusedxml"] = defusedxml
+        sys.modules["defusedxml.ElementTree"] = et
+
+
+_stub_heavy_imports()
+
+REPO = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "scrape_docs", REPO / "scripts" / "scrape-docs.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+scrape_docs = importlib.util.module_from_spec(SPEC)
+# Register before exec_module: Python 3.12+ dataclasses look the module up in
+# sys.modules during class construction.
+sys.modules["scrape_docs"] = scrape_docs
+SPEC.loader.exec_module(scrape_docs)
+
+
+@dataclass
+class FakeStage:
+    name: str
+    urls: list[str]
+    extract_md: dict[str, str]  # url -> markdown
+
+
+def _install_fakes(test: unittest.TestCase, stages: dict[str, FakeStage]) -> None:
+    """Patch discovery + fetch + extraction helpers to play deterministic stages."""
+
+    test.addCleanup(setattr, scrape_docs, "discover_doc_subdomain", scrape_docs.discover_doc_subdomain)
+    test.addCleanup(setattr, scrape_docs, "discover_openapi", scrape_docs.discover_openapi)
+    test.addCleanup(setattr, scrape_docs, "discover_llms_full", scrape_docs.discover_llms_full)
+    test.addCleanup(setattr, scrape_docs, "discover_llms_txt", scrape_docs.discover_llms_txt)
+    test.addCleanup(setattr, scrape_docs, "discover_mint_json", scrape_docs.discover_mint_json)
+    test.addCleanup(setattr, scrape_docs, "discover_sitemap", scrape_docs.discover_sitemap)
+    test.addCleanup(setattr, scrape_docs, "crawl_from_seed", scrape_docs.crawl_from_seed)
+    test.addCleanup(setattr, scrape_docs, "fetch_many", scrape_docs.fetch_many)
+    test.addCleanup(setattr, scrape_docs, "html_to_markdown", scrape_docs.html_to_markdown)
+
+    scrape_docs.discover_doc_subdomain = lambda base_url: None
+    scrape_docs.discover_openapi = lambda base_url, out_dir: None
+    scrape_docs.discover_llms_full = lambda base_url: None
+    scrape_docs.discover_llms_txt = lambda base_url: stages["llms.txt"].urls if "llms.txt" in stages else []
+    scrape_docs.discover_mint_json = lambda base_url: stages["mint.json"].urls if "mint.json" in stages else []
+    scrape_docs.discover_sitemap = lambda base_url: stages["sitemap.xml"].urls if "sitemap.xml" in stages else []
+
+    # crawl returns (url, html, fetcher) tuples
+    crawl_pages = stages.get("crawl")
+    def _fake_crawl(seed, max_depth, max_pages, concurrency):
+        if crawl_pages is None:
+            return []
+        return [(u, f"<html>{u}</html>", "fake") for u in crawl_pages.urls]
+    scrape_docs.crawl_from_seed = _fake_crawl
+
+    # fetch_many returns (successes, failures); successes are (url, html, fetcher)
+    def _fake_fetch_many(urls, concurrency):
+        successes = [(u, f"<html>{u}</html>", "fake") for u in urls]
+        return successes, []
+    scrape_docs.fetch_many = _fake_fetch_many
+
+    # html_to_markdown looks up the URL in the stage's extract_md table
+    all_md: dict[str, str] = {}
+    for stage in stages.values():
+        all_md.update(stage.extract_md)
+    def _fake_html_to_md(html, url):
+        return all_md.get(url, "")
+    scrape_docs.html_to_markdown = _fake_html_to_md
+
+
+def _make_md(url: str, size: int = 600) -> str:
+    """Markdown ≥ MIN_MARKDOWN_CHARS so it passes the size filter."""
+    return f"# {url}\n\n" + ("body content " * (size // 12))
+
+
+class DiscoveryLadderTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="scrape-test-"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_thin_llms_falls_through_to_sitemap(self):
+        """docs.github.com pattern: 19-page llms.txt traps below the 20-page
+        gate. Sitemap with 25 pages should win, not llms.txt.
+        """
+        llms_urls = [f"https://example.com/api/endpoint/{i}" for i in range(19)]
+        sitemap_urls = [f"https://example.com/docs/page-{i}" for i in range(25)]
+        stages = {
+            "llms.txt": FakeStage(
+                "llms.txt", llms_urls, {u: _make_md(u) for u in llms_urls}
+            ),
+            "sitemap.xml": FakeStage(
+                "sitemap.xml", sitemap_urls, {u: _make_md(u) for u in sitemap_urls}
+            ),
+        }
+        _install_fakes(self, stages)
+
+        result = scrape_docs.run_pipeline(
+            base_url="https://example.com",
+            out_dir=self.tmp,
+            min_pages=20,
+            max_pages=500,
+            concurrency=4,
+        )
+        self.assertEqual(result.discovery, "sitemap.xml")
+        self.assertEqual(len(result.pages), 25)
+        # Files left on disk should match the winner only — llms.txt's 19
+        # files should have been cleaned up by commit().
+        md_files = list(self.tmp.glob("**/*.md"))
+        self.assertEqual(len(md_files), 25, f"expected 25 surviving .md files, got {len(md_files)}")
+
+    def test_healthy_llms_accepted_short_circuits(self):
+        """Healthy llms.txt with ≥ min_pages should be accepted on first match."""
+        urls = [f"https://example.com/docs/page-{i}" for i in range(30)]
+        stages = {
+            "llms.txt": FakeStage("llms.txt", urls, {u: _make_md(u) for u in urls}),
+            # mint.json/sitemap should never be probed in this scenario, but
+            # provide them anyway to confirm short-circuit doesn't dip deeper.
+            "sitemap.xml": FakeStage("sitemap.xml", [f"https://example.com/s/{i}" for i in range(50)], {}),
+        }
+        _install_fakes(self, stages)
+
+        result = scrape_docs.run_pipeline(
+            base_url="https://example.com",
+            out_dir=self.tmp,
+            min_pages=20,
+            max_pages=500,
+            concurrency=4,
+        )
+        self.assertEqual(result.discovery, "llms.txt")
+        self.assertEqual(len(result.pages), 30)
+
+    def test_micro_product_falls_back_to_llms(self):
+        """6-page product: nothing clears min_pages, but llms.txt cleared the
+        ABS_FLOOR. Should be retained as a fallback, not silently dropped.
+        """
+        urls = [f"https://tiny.example/docs/page-{i}" for i in range(6)]
+        stages = {
+            "llms.txt": FakeStage("llms.txt", urls, {u: _make_md(u) for u in urls}),
+        }
+        _install_fakes(self, stages)
+
+        result = scrape_docs.run_pipeline(
+            base_url="https://tiny.example",
+            out_dir=self.tmp,
+            min_pages=20,
+            max_pages=500,
+            concurrency=4,
+        )
+        # Below min_pages, but above floor — fallback retains it with tag.
+        self.assertIn("llms.txt", result.discovery)
+        self.assertIn("below min_pages", result.discovery)
+        self.assertEqual(len(result.pages), 6)
+
+    def test_below_floor_discarded(self):
+        """A stage with < ABS_FLOOR pages is noise; should be cleaned, not retained."""
+        urls = [f"https://example.com/x/{i}" for i in range(3)]
+        stages = {
+            "llms.txt": FakeStage("llms.txt", urls, {u: _make_md(u) for u in urls}),
+        }
+        _install_fakes(self, stages)
+
+        result = scrape_docs.run_pipeline(
+            base_url="https://example.com",
+            out_dir=self.tmp,
+            min_pages=20,
+            max_pages=500,
+            concurrency=4,
+        )
+        self.assertEqual(result.discovery, "")
+        self.assertEqual(len(result.pages), 0)
+        md_files = list(self.tmp.glob("**/*.md"))
+        self.assertEqual(len(md_files), 0, f"orphans not cleaned: {md_files}")
+
+    def test_largest_fallback_wins(self):
+        """When no stage clears min_pages but two stages clear ABS_FLOOR,
+        keep the larger one and clean the smaller.
+        """
+        small = [f"https://example.com/a/{i}" for i in range(7)]
+        bigger = [f"https://example.com/b/{i}" for i in range(15)]
+        stages = {
+            "llms.txt": FakeStage("llms.txt", small, {u: _make_md(u) for u in small}),
+            "sitemap.xml": FakeStage("sitemap.xml", bigger, {u: _make_md(u) for u in bigger}),
+        }
+        _install_fakes(self, stages)
+
+        result = scrape_docs.run_pipeline(
+            base_url="https://example.com",
+            out_dir=self.tmp,
+            min_pages=20,
+            max_pages=500,
+            concurrency=4,
+        )
+        self.assertIn("sitemap.xml", result.discovery)
+        self.assertIn("below min_pages", result.discovery)
+        self.assertEqual(len(result.pages), 15)
+        md_files = list(self.tmp.glob("**/*.md"))
+        self.assertEqual(len(md_files), 15, f"expected 15 fallback files, got {len(md_files)}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- The discovery ladder no longer accepts a stage just because it cleared 5 pages. It now accepts on the first stage that clears `min_pages` (the coverage gate); otherwise it tracks the largest stage above a 5-page floor and falls back to it only if no later stage produces enough.
- Below-floor stages (< 5 pages) are cleaned up so they don't leave orphan `.md` files alongside the winner.
- When falling back below `min_pages`, `result.discovery` is tagged `"(below min_pages)"` so `coverage.json` reflects the shortfall honestly instead of silently accepting a doomed stage.
- Adds `tests/test_scrape_docs_pipeline.py` (5 cases). Runs under bare `python3` — no pytest, no `.venv-scrape` required (heavy native deps are stubbed).

## Why
On `docs.github.com`, `llms.txt` advertises 21 internal API-endpoint URLs (`/api/pagelist/...`). The scraper fetched 19, which cleared the old `min(min_pages, 5)` accept threshold but failed the 20-page coverage gate. Sitemap (~3000 real doc URLs) was never tried. Issue #68 details the trace.

The "best-of" rewrite makes the ladder behave like a ladder: each rung is a real probe, not a commitment.

## Test plan
- [x] `python3 tests/test_scrape_docs_pipeline.py` — all 5 pass.
  - `test_thin_llms_falls_through_to_sitemap` — 19-page llms.txt + 25-page sitemap → sitemap wins, llms files cleaned.
  - `test_healthy_llms_accepted_short_circuits` — 30-page llms.txt → accepted, sitemap not probed.
  - `test_micro_product_falls_back_to_llms` — 6-page product → fallback retains it, discovery tagged `(below min_pages)`.
  - `test_below_floor_discarded` — 3-page stage → cleaned, no orphans.
  - `test_largest_fallback_wins` — 7-page llms + 15-page sitemap, neither clears gate → sitemap kept, llms cleaned.
- [x] `python3 -m py_compile scripts/scrape-docs.py` clean.
- [ ] Manual check on a real target (Stripe / Supabase) once branch is reviewable — flagged as risk in the issue.

## Risk
Medium per the issue. Behavior changes for any product that previously passed the 5-page accept threshold but failed the gate (those got `passed=false` before; now they still get `passed=false` but with a real attempt at later stages and a clearer discovery label). No regression for products that already cleared `min_pages` on first match.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)