### PR TITLE
feat(loops): make inspect/build/qa/architecture agent configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ test.txt
 # Tool state
 .omc/
 .omx/
+.superset/
 target-docs/
 
 # Test artifacts

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,5 +1,0 @@
-{
-  "setup": [],
-  "teardown": [],
-  "run": []
-}

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ The clone sends real emails via AWS SES, verifies real domains, auto-configures 
 
 A single watchdog orchestrator (`ralph/ralph-watchdog.sh`) drives four phases. It auto-restarts failures, tracks token cost against a budget cap, refuses to enter QA until the workspace proves it builds, and detects zero-progress QA stalls. Up to 5 build-QA cycles per feature.
 
+Every loop phase is backed by either **Codex** (default, `reasoning_effort=low` — empirically best across all four loops) or **Claude**. You pick during onboarding; the choice lands in `ralph-config.json` as `inspectAgent` / `buildAgent` / `qaAgent` / `architectureAgent` (plus `reasoningEffort` for codex), and each loop reads its own field at runtime.
+
 | Phase | Agent | What It Does |
 |-------|-------|-------------|
-| **1. Inspect** | Claude + [Ever CLI](https://foreverbrowsing.com) | Browses the target, scrapes docs deterministically (Scrapling + trafilatura), captures screenshots, generates a PRD with 50+ features |
-| **1.5. Architecture** | Claude (architect) | Turns the PRD into evidence-based decisions — process topology, data model, infra, auth, packaging — recorded in `ralph/architecture-decisions.json` |
-| **2. Build** | Claude | For each feature: vertically slices it into ≤4 testable phases (Phase 2.5), then implements each slice TDD-first, commits and pushes after every slice |
-| **3. QA** | [Codex](https://github.com/openai/codex) + [Ever CLI](https://foreverbrowsing.com) | Per-feature progressive disclosure: Functional → API Contract → Security → Accessibility. Fixes bugs and re-tests until features pass |
+| **1. Inspect** | configurable (default: Codex) + [Ever CLI](https://foreverbrowsing.com) | Browses the target, scrapes docs deterministically (Scrapling + trafilatura), captures screenshots, generates a PRD with 50+ features |
+| **1.5. Architecture** | configurable (default: Codex) | Turns the PRD into evidence-based decisions — process topology, data model, infra, auth, packaging — recorded in `ralph/architecture-decisions.json` |
+| **2. Build** | configurable (default: Codex) | For each feature: vertically slices it into ≤4 testable phases (Phase 2.5), then implements each slice TDD-first, commits and pushes after every slice |
+| **3. QA** | configurable (default: Codex) + [Ever CLI](https://foreverbrowsing.com) | Per-feature progressive disclosure: Functional → API Contract → Security → Accessibility. Fixes bugs and re-tests until features pass |
 
 ---
 
@@ -55,14 +57,14 @@ You can install these ahead of time, or onboarding will prompt you when it needs
 
 ### Coding CLI
 
-The agent that drives Inspect, Build, and QA. We recommend running **Claude Code for Build** and **Codex for QA** so the QA pass is independent.
+The agent that drives Inspect, Architecture, Build, and QA. You pick one during onboarding and the choice applies to every loop.
 
 | Tool | Install |
 |------|---------|
-| [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) **(recommended)** | `npm install -g @anthropic-ai/claude-code` |
-| [Codex CLI](https://github.com/openai/codex) **(recommended)** | `npm install -g @openai/codex` |
+| [Codex CLI](https://github.com/openai/codex) **(default — `reasoning_effort=low`)** | `npm install -g @openai/codex` |
+| [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) | `npm install -g @anthropic-ai/claude-code` |
 
-Any other coding CLI works too — the prompts are plain markdown in `ralph/build-prompt.md` and `ralph/qa-prompt.md`. The watchdog shells out to `claude` and `codex` by default; swap the commands in `ralph/build-ralph.sh` / `ralph/qa-ralph.sh` if you're using something else.
+Codex at low reasoning effort is the empirical best across every loop and is the default. You can override per phase by editing `inspectAgent` / `buildAgent` / `qaAgent` / `architectureAgent` in `ralph-config.json` after onboarding — the loop scripts read those fields at runtime via `ralph/lib/agent-runner.sh`.
 
 ### Browser Agent
 

--- a/ralph/build-ralph.sh
+++ b/ralph/build-ralph.sh
@@ -25,6 +25,10 @@ ITERATIONS="${1:-999}"
 [ -f ralph-config.json ] || { echo "ERROR: ralph-config.json not found. Run ./ralph/onboard.sh first."; exit 1; }
 [ -f BUILD_GUIDE.md ] || { echo "ERROR: BUILD_GUIDE.md not found. Run ./ralph/onboard.sh first."; exit 1; }
 
+# shellcheck source=lib/agent-runner.sh
+. "$(dirname "$0")/lib/agent-runner.sh"
+load_agent_config build
+
 STACK_PROFILE=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('stackProfile', 'unknown'))" 2>/dev/null || echo "unknown")
 LANGUAGE=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('language', 'unknown'))" 2>/dev/null || echo "unknown")
 
@@ -41,6 +45,7 @@ fi
 echo "=== RALPH-TO-RALPH: Phase 2 (Build) ==="
 echo "Iterations: $ITERATIONS"
 echo "Stack: $LANGUAGE / $STACK_PROFILE"
+echo "Agent: $(agent_label)"
 echo "Build contract: read BUILD_GUIDE.md, prefer make targets over stack-specific CLIs"
 echo ""
 
@@ -154,7 +159,7 @@ for ((i=1; i<=$ITERATIONS; i++)); do
     # REBUILD MODE: Feature failed QA previously — use root-cause analysis prompt
     echo "  → Rebuild mode: QA failures detected, providing root-cause context"
 
-    result=$(timeout 1200 claude -p --dangerously-skip-permissions --model claude-opus-4-6 \
+    result=$(agent_invoke 1200 \
 "@ralph/build-prompt.md @ralph/pre-setup.md @build-spec.md @prd.json @build-progress.txt @CLAUDE.md @ralph-config.json @qa-report.json
 
 ITERATION: $i of $ITERATIONS
@@ -187,7 +192,7 @@ Output <promise>COMPLETE</promise> only if ALL features pass.")
 
   else
     # FRESH BUILD MODE: No QA failures — standard build prompt
-    result=$(timeout 1200 claude -p --dangerously-skip-permissions --model claude-opus-4-6 \
+    result=$(agent_invoke 1200 \
 "@ralph/build-prompt.md @ralph/pre-setup.md @build-spec.md @prd.json @build-progress.txt @CLAUDE.md @ralph-config.json
 
 ITERATION: $i of $ITERATIONS

--- a/ralph/inspect-ralph.sh
+++ b/ralph/inspect-ralph.sh
@@ -15,6 +15,9 @@ else
 fi
 
 [ -f ralph-config.json ] || { echo "ERROR: ralph-config.json not found. Run ./ralph/onboard.sh first."; exit 1; }
+# shellcheck source=lib/agent-runner.sh
+. "$(dirname "$0")/lib/agent-runner.sh"
+load_agent_config inspect
 BROWSER_AGENT=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('browserAgent', 'ever'))" 2>/dev/null || echo "ever")
 # docsUrl is set during onboarding when the actual docs live on a different
 # subdomain (e.g. docs.stripe.com vs stripe.com). If present, the scraper
@@ -24,6 +27,7 @@ DOCS_URL=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('
 echo "=== RALPH-TO-RALPH: Phase 1 (Inspect) ==="
 echo "Target: $TARGET_URL"
 echo "Iterations: $ITERATIONS"
+echo "Agent: $(agent_label)"
 echo ""
 
 # Initialize files
@@ -145,7 +149,7 @@ for ((i=1; i<=$ITERATIONS; i++)); do
 
   _BROWSER_REF=""
   [ "$BROWSER_AGENT" = "ever" ] && _BROWSER_REF="@ralph/ever-cli-reference.md"
-  result=$(timeout 1200 claude -p --dangerously-skip-permissions --model claude-opus-4-6 \
+  result=$(agent_invoke 1200 \
 "@ralph/inspect-prompt.md @ralph/inspect-spec.md $_BROWSER_REF @prd.json @inspect-progress.txt @ralph/pre-setup.md @ralph-config.json
 
 TARGET URL: $TARGET_URL

--- a/ralph/lib/agent-runner.sh
+++ b/ralph/lib/agent-runner.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# agent-runner.sh — shared helper so each loop phase (inspect / build / qa /
+# architecture) can be backed by either codex or claude, with a single
+# reasoning_effort knob for codex.
+#
+# Call `load_agent_config <phase>` to populate RALPH_AGENT and
+# RALPH_REASONING_EFFORT from ralph-config.json, then call
+# `agent_invoke <timeout_seconds> <prompt>` to actually run the agent.
+#
+# Per-phase keys in ralph-config.json:
+#   inspectAgent, buildAgent, qaAgent, architectureAgent  (enum: codex | claude)
+#   reasoningEffort                                       (enum: minimal | low | medium | high)
+#
+# Defaults: codex, reasoningEffort=low (best across loops, per onboarding).
+
+# Resolve Python the same way the loop scripts do.
+if command -v uv &>/dev/null; then
+  _AGENT_PY="uv run python3"
+else
+  _AGENT_PY="python3"
+fi
+
+# Read a single key from ralph-config.json. Falls back to $2 if missing.
+_agent_cfg_get() {
+  local key="$1" default="$2"
+  $_AGENT_PY -c "
+import json
+try:
+    cfg = json.load(open('ralph-config.json'))
+    val = cfg.get('$key')
+    print(val if val else '$default')
+except Exception:
+    print('$default')
+" 2>/dev/null || echo "$default"
+}
+
+# load_agent_config <phase>
+# Sets:
+#   RALPH_AGENT             — codex | claude
+#   RALPH_REASONING_EFFORT  — minimal | low | medium | high (codex-only)
+load_agent_config() {
+  local phase="$1"
+  local key
+  case "$phase" in
+    inspect)      key="inspectAgent" ;;
+    build)        key="buildAgent" ;;
+    qa)           key="qaAgent" ;;
+    architecture) key="architectureAgent" ;;
+    *)            key="" ;;
+  esac
+
+  local agent="codex"
+  if [ -n "$key" ]; then
+    agent=$(_agent_cfg_get "$key" "codex")
+  fi
+  case "$agent" in
+    codex|claude) ;;
+    *) agent="codex" ;;
+  esac
+
+  local effort
+  effort=$(_agent_cfg_get "reasoningEffort" "low")
+  case "$effort" in
+    minimal|low|medium|high) ;;
+    *) effort="low" ;;
+  esac
+
+  export RALPH_AGENT="$agent"
+  export RALPH_REASONING_EFFORT="$effort"
+}
+
+# agent_invoke <timeout_seconds> <prompt>
+# Runs the configured agent with the given prompt and prints its stdout.
+agent_invoke() {
+  local timeout_s="$1"
+  local prompt="$2"
+  local agent="${RALPH_AGENT:-codex}"
+  local effort="${RALPH_REASONING_EFFORT:-low}"
+
+  if [ "$agent" = "codex" ]; then
+    timeout "$timeout_s" codex exec --dangerously-bypass-approvals-and-sandbox \
+      -c model_reasoning_effort="$effort" \
+      "$prompt"
+  else
+    timeout "$timeout_s" claude -p --dangerously-skip-permissions --model claude-opus-4-6 \
+      "$prompt"
+  fi
+}
+
+# agent_label — short human-readable label like "codex (low)" or "claude".
+agent_label() {
+  local agent="${RALPH_AGENT:-codex}"
+  if [ "$agent" = "codex" ]; then
+    echo "codex (reasoning_effort=${RALPH_REASONING_EFFORT:-low})"
+  else
+    echo "claude"
+  fi
+}

--- a/ralph/onboard.sh
+++ b/ralph/onboard.sh
@@ -248,12 +248,16 @@ if [ -f ".onboard-answers.tmp" ] && [ ! -f "ralph-config.json" ]; then
   source .onboard-answers.tmp
   # Ensure DEPLOYMENT_PROFILE is set for older tmp files
   DEPLOYMENT_PROFILE="${DEPLOYMENT_PROFILE:-fast-starter}"
+  # Defaults for older tmp files written before the agent prompt was added
+  LOOP_AGENT="${LOOP_AGENT:-codex}"
+  REASONING_EFFORT="${REASONING_EFFORT:-low}"
   echo "Found saved answers from a previous run:"
   echo "  Target:   $TARGET_URL"
   echo "  Clone:    $CLONE_NAME"
   echo "  Profile:  $DEPLOYMENT_PROFILE"
   echo "  Stack:    $CLOUD_PROVIDER${CUSTOM_STACK_DESC:+ (custom: $CUSTOM_STACK_DESC)}"
   echo "  Auth:     $AUTH_MODE"
+  echo "  Agent:    $LOOP_AGENT$([ "$LOOP_AGENT" = "codex" ] && echo " (reasoning_effort=$REASONING_EFFORT)")"
   echo ""
   read -rp "Resume with these? [Y/n]: " _RESUME_ANSWERS
   if [[ "${_RESUME_ANSWERS:-y}" =~ ^[Yy] ]]; then
@@ -678,6 +682,43 @@ case "${BROWSER_CHOICE:-1}" in
     ;;
 esac
 
+echo ""
+echo "Which coding agent should drive the Inspect / Build / QA / Architecture loops?"
+echo ""
+echo "  1) Codex (recommended — empirically best across all loops at low reasoning effort)"
+echo "     Requires: npm install -g @openai/codex"
+echo ""
+echo "  2) Claude (claude -p, claude-opus-4-6)"
+echo "     Requires: claude CLI (https://docs.anthropic.com/en/docs/claude-code)"
+echo ""
+read -rp "Choose loop agent [1]: " AGENT_CHOICE
+AGENT_CHOICE="${AGENT_CHOICE//[[:space:]]/}"
+case "${AGENT_CHOICE:-1}" in
+  1|codex)  LOOP_AGENT="codex" ;;
+  2|claude) LOOP_AGENT="claude" ;;
+  *)
+    echo "Invalid choice. Using Codex."
+    LOOP_AGENT="codex"
+    ;;
+esac
+
+REASONING_EFFORT="low"
+if [ "$LOOP_AGENT" = "codex" ]; then
+  echo ""
+  echo "Codex reasoning effort (applies to every loop):"
+  echo "  1) low     (recommended — fastest and cheapest, best empirical results)"
+  echo "  2) medium"
+  echo "  3) high"
+  echo "  4) minimal"
+  read -rp "Choose [1]: " EFFORT_CHOICE
+  case "${EFFORT_CHOICE//[[:space:]]/}" in
+    2|medium)  REASONING_EFFORT="medium" ;;
+    3|high)    REASONING_EFFORT="high" ;;
+    4|minimal) REASONING_EFFORT="minimal" ;;
+    *)         REASONING_EFFORT="low" ;;
+  esac
+fi
+
 fi  # end _SKIP_QA=false block
 
 # ── Re-verify cloud CLI auth if resuming (sessions can expire between runs) ──
@@ -721,7 +762,26 @@ STACK_PROFILE="dashboard-app"
   printf 'LANGUAGE=%q\n'         "$LANGUAGE"
   printf 'STACK_PROFILE=%q\n'    "$STACK_PROFILE"
   printf 'DEPLOYMENT_PROFILE=%q\n' "$DEPLOYMENT_PROFILE"
+  printf 'LOOP_AGENT=%q\n'       "$LOOP_AGENT"
+  printf 'REASONING_EFFORT=%q\n' "$REASONING_EFFORT"
 } > .onboard-answers.tmp
+
+# Verify the chosen loop agent is installed — fail fast, but only AFTER saving
+# answers so the user can fix the install and rerun without re-prompting.
+if [ "$LOOP_AGENT" = "codex" ] && ! command -v codex &>/dev/null; then
+  echo ""
+  echo "ERROR: Codex CLI is not installed but you selected it as the loop agent."
+  echo "  Install: npm install -g @openai/codex"
+  echo "  Re-run ./ralph/onboard.sh once installed (your answers are saved)."
+  exit 1
+fi
+if [ "$LOOP_AGENT" = "claude" ] && ! command -v claude &>/dev/null; then
+  echo ""
+  echo "ERROR: Claude CLI is not installed but you selected it as the loop agent."
+  echo "  Install: https://docs.anthropic.com/en/docs/claude-code"
+  echo "  Re-run ./ralph/onboard.sh once installed (your answers are saved)."
+  exit 1
+fi
 
 echo ""
 echo "--- Summary ---"
@@ -735,6 +795,11 @@ echo "Cloud:     $CLOUD_PROVIDER"
 echo "Language:  $LANGUAGE (scripted default template)"
 echo "Stack:     $STACK_PROFILE (scripted default template)"
 echo "Database:  Postgres (template default)"
+if [ "$LOOP_AGENT" = "codex" ]; then
+  echo "Agent:     codex (reasoning_effort=$REASONING_EFFORT)"
+else
+  echo "Agent:     claude"
+fi
 if [ "$SKIP_DEPLOY" = "true" ]; then
   _DEPLOY_LABEL="No (build locally only)"
 elif [ "$CLOUD_PROVIDER" = "vercel" ]; then
@@ -784,6 +849,8 @@ The user has already provided their answers:
 - Docs URL: ${DOCS_URL:-(not set — auto-discover during scrape)}. If set, save as 'docsUrl' in ralph-config.json. The doc scraper will target this URL instead of probing subdomains.
 - Language: $LANGUAGE. Set as 'language' in ralph-config.json. This selects the stack template under .claude/skills/ralph-to-ralph-onboard/templates/.
 - Stack profile: $STACK_PROFILE. Set as 'stackProfile' in ralph-config.json.
+- Loop agent: $LOOP_AGENT (codex or claude). Set all four of 'inspectAgent', 'buildAgent', 'qaAgent', and 'architectureAgent' to this value in ralph-config.json.
+- Reasoning effort: $REASONING_EFFORT (applies when an agent is codex). Set as 'reasoningEffort' in ralph-config.json.
 
 SKIP Steps 1 and 2 (already answered above). Start directly from Step 3 (Technical Architecture Scan).
 Research the target product, generate ralph-config.json (INCLUDING 'language' and 'stackProfile' — required), and rewrite the provider-specific config files (preflight, pre-setup, CLAUDE.md, inspect-prompt, build-prompt). Do NOT create package.json, tsconfig.json, schema.ts, or run npm install — the wrapper invokes setup-stack.sh afterwards to install the template.
@@ -830,6 +897,26 @@ if c['cloudProvider'] not in ('aws', 'gcp', 'azure', 'vercel', 'custom'):
     print(f'ERROR: invalid cloudProvider: {c[\"cloudProvider\"]}', file=sys.stderr)
     sys.exit(1)
 " || exit 1
+
+  # ── Force-write the user's loop agent choice into ralph-config.json. ──
+  # Claude is instructed to write these fields, but we re-apply them here so
+  # the user's choice is the source of truth regardless of what Claude did.
+  _LOOP_AGENT="$LOOP_AGENT" _REASONING_EFFORT="$REASONING_EFFORT" $PY -c "
+import json, os
+agent = os.environ['_LOOP_AGENT']
+effort = os.environ['_REASONING_EFFORT']
+with open('ralph-config.json') as f:
+    cfg = json.load(f)
+cfg['inspectAgent'] = agent
+cfg['buildAgent'] = agent
+cfg['qaAgent'] = agent
+cfg['architectureAgent'] = agent
+cfg['reasoningEffort'] = effort
+with open('ralph-config.json', 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+print(f'Wrote loop agent config: {agent} (reasoning_effort={effort})')
+"
 
   # ── Install the stack template (same path the skill uses) ──
   # setup-stack.sh reads language + stackProfile from ralph-config.json, copies

--- a/ralph/qa-ralph.sh
+++ b/ralph/qa-ralph.sh
@@ -33,6 +33,10 @@ get_qa_timeout() {
 
 [ -f ralph-config.json ] || { echo "ERROR: ralph-config.json not found. Run ./ralph/onboard.sh first."; exit 1; }
 [ -f BUILD_GUIDE.md ] || { echo "ERROR: BUILD_GUIDE.md not found. Run ./ralph/onboard.sh first."; exit 1; }
+
+# shellcheck source=lib/agent-runner.sh
+. "$(dirname "$0")/lib/agent-runner.sh"
+load_agent_config qa
 BROWSER_AGENT=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('browserAgent', 'ever'))" 2>/dev/null || echo "ever")
 STACK_PROFILE=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('stackProfile', 'unknown'))" 2>/dev/null || echo "unknown")
 LANGUAGE=$($PY -c "import json; print(json.load(open('ralph-config.json')).get('language', 'unknown'))" 2>/dev/null || echo "unknown")
@@ -76,9 +80,10 @@ if [ ! -f "prd.json" ]; then
   exit 1
 fi
 
-echo "=== RALPH-TO-RALPH: Phase 3 (QA with Codex) ==="
+echo "=== RALPH-TO-RALPH: Phase 3 (QA) ==="
 echo "Target: ${TARGET_URL:-none}"
 echo "Stack: $LANGUAGE / $STACK_PROFILE"
+echo "Agent: $(agent_label)"
 echo "Sub-phases: progressive (base + category-specific modules)"
 echo "Command contract: prefer make targets and BUILD_GUIDE.md over hardcoded stack CLIs"
 echo ""
@@ -424,7 +429,7 @@ except:
   done
   QA_PROMPT+=$'\n'"$(cat ralph/qa/footer.md)"
 
-  result=$(timeout "$QA_TIMEOUT" codex exec --dangerously-bypass-approvals-and-sandbox \
+  result=$(agent_invoke "$QA_TIMEOUT" \
 "$QA_PROMPT
 
 == FEATURE TO TEST ==
@@ -486,7 +491,7 @@ Then:
   fi
 
   # No promise = crash or context overflow. Record as partial and move on.
-  echo "WARNING: No promise from Codex for $FEATURE_ID (attempt $ATTEMPT). Recording as partial..."
+  echo "WARNING: No promise from QA agent ($(agent_label)) for $FEATURE_ID (attempt $ATTEMPT). Recording as partial..."
   $PY -c "
 import json, sys
 fid = sys.argv[1]
@@ -498,14 +503,14 @@ report.append({
     'attempt': attempt,
     'status': 'partial',
     'sub_phases': {
-        'functional':    {'status': 'skip', 'notes': 'Codex crashed or timed out'},
-        'api_contract':  {'status': 'skip', 'notes': 'Codex crashed or timed out'},
-        'security':      {'status': 'skip', 'notes': 'Codex crashed or timed out'},
-        'accessibility': {'status': 'skip', 'notes': 'Codex crashed or timed out'}
+        'functional':    {'status': 'skip', 'notes': 'QA agent crashed or timed out'},
+        'api_contract':  {'status': 'skip', 'notes': 'QA agent crashed or timed out'},
+        'security':      {'status': 'skip', 'notes': 'QA agent crashed or timed out'},
+        'accessibility': {'status': 'skip', 'notes': 'QA agent crashed or timed out'}
     },
-    'tested_steps': ['Codex crashed or timed out'],
+    'tested_steps': ['QA agent crashed or timed out'],
     'bugs_found': [],
-    'fix_description': 'Codex did not complete'
+    'fix_description': 'QA agent did not complete'
 })
 with open('qa-report.json', 'w') as f:
     json.dump(report, f, indent=2)

--- a/ralph/ralph-watchdog.sh
+++ b/ralph/ralph-watchdog.sh
@@ -9,7 +9,11 @@
 # Usage: ./ralph/ralph-watchdog.sh <target-url>
 
 set -euo pipefail
-cd "$(dirname "$0")/.."
+_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$_SCRIPT_DIR/.."
+
+# shellcheck source=lib/agent-runner.sh
+. "$_SCRIPT_DIR/lib/agent-runner.sh"
 
 TARGET_URL="${1:?Usage: $0 <target-url>}"
 LOCKFILE=".ralph-watchdog.lock"
@@ -600,15 +604,23 @@ done
 # ─── PHASE 1.5: Architecture Design ───
 
 if inspect_done && ! architecture_done; then
-  log "Phase 1.5: Designing product architecture..."
+  load_agent_config architecture
+  log "Phase 1.5: Designing product architecture via $(agent_label)..."
   check_time_budget
 
   PHASE_LOG_TMP=$(mktemp)
-  # Invoke architect agent
-  run_phase "$PHASE_LOG_TMP" "Phase 1.5: architecture (claude -p)" 30 \
-    claude -p --dangerously-skip-permissions --model claude-opus-4-6 \
-    "@ralph/architecture-prompt.md @prd.json @target-docs/INDEX.md @ralph-config.json"
-  ARCHITECTURE_EXIT="$PHASE_EXIT"
+  # Invoke architect agent. agent_invoke is a shell function, so we run the
+  # pipefail-safe pattern inline rather than passing it to run_phase (which
+  # execs an external command).
+  set +e +o pipefail
+  agent_invoke 1800 "@ralph/architecture-prompt.md @prd.json @target-docs/INDEX.md @ralph-config.json" \
+    2>&1 | tee -a "$LOG_FILE" > "$PHASE_LOG_TMP"
+  ARCHITECTURE_EXIT=${PIPESTATUS[0]}
+  set -e -o pipefail
+  if [ "$ARCHITECTURE_EXIT" -ne 0 ]; then
+    log "Phase 1.5: architecture ($(agent_label)) exited non-zero (exit=$ARCHITECTURE_EXIT). Last 30 lines of phase output:"
+    tail -n 30 "$PHASE_LOG_TMP" 2>/dev/null | sed 's/^/    /' | tee -a "$LOG_FILE" >/dev/null
+  fi
 
   LOG_TAIL=$(tail -50 "$PHASE_LOG_TMP")
   COST_INFO=$(update_cost "architecture" "architecture" "$LOG_TAIL")

--- a/schemas/ralph-config.schema.json
+++ b/schemas/ralph-config.schema.json
@@ -103,6 +103,36 @@
       "default": "ever",
       "description": "Browser automation agent for QA and inspection phases"
     },
+    "inspectAgent": {
+      "type": "string",
+      "enum": ["codex", "claude"],
+      "default": "codex",
+      "description": "Coding agent CLI driving the Inspect loop"
+    },
+    "buildAgent": {
+      "type": "string",
+      "enum": ["codex", "claude"],
+      "default": "codex",
+      "description": "Coding agent CLI driving the Build loop"
+    },
+    "qaAgent": {
+      "type": "string",
+      "enum": ["codex", "claude"],
+      "default": "codex",
+      "description": "Coding agent CLI driving the QA loop"
+    },
+    "architectureAgent": {
+      "type": "string",
+      "enum": ["codex", "claude"],
+      "default": "codex",
+      "description": "Coding agent CLI driving the Phase 1.5 architecture design step"
+    },
+    "reasoningEffort": {
+      "type": "string",
+      "enum": ["minimal", "low", "medium", "high"],
+      "default": "low",
+      "description": "Codex reasoning_effort applied to all loops backed by codex"
+    },
     "skipDeployment": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
## Summary
- Adds `ralph/lib/agent-runner.sh` so each loop phase reads its own agent (`inspectAgent` / `buildAgent` / `qaAgent` / `architectureAgent`, codex|claude) and a shared `reasoningEffort` (codex only) from `ralph-config.json` instead of hardcoding `claude -p` (or `codex exec` for QA).
- Wires the helper into `inspect-ralph.sh`, `build-ralph.sh` (both fresh + rebuild prompts), `qa-ralph.sh`, and the Phase 1.5 architecture call in `ralph-watchdog.sh`. Each phase logs its agent label at startup.
- Onboarding asks the loop agent (default Codex) and reasoning effort (default low, codex only), saves into `.onboard-answers.tmp`, fail-fast verifies the chosen CLI is installed, and force-writes the four agent fields + `reasoningEffort` into `ralph-config.json` after Claude's config-generation step so the user's selection wins regardless of what Claude wrote.
- Schema gains the new fields with `default: codex` / `default: low`; README updated to describe the configurable default.
- Drops the tracked `.superset/config.json` and gitignores `.superset/`.

Default is **codex with `reasoning_effort=low`** across all loops — empirically the best setting.

## Test plan
- [x] `bash -n` on every modified script
- [x] Smoke-tested `agent-runner.sh` end-to-end with a mixed-agent config (`inspectAgent=claude`, others=codex, `reasoningEffort=medium`) — per-phase resolution returns the right CLI + effort
- [x] `node scripts/validate-schemas.mjs` passes
- [ ] Run a full onboarding (`./ralph/onboard.sh`) in a throwaway dir to confirm the new agent prompt + post-Claude config patch lands the right keys
- [ ] Run a build cycle with codex/low to confirm the helper invokes `codex exec --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort=low` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)