### PR TITLE
Reduce loop token waste with lazy context manifests

### DIFF
--- a/ralph/architecture-prompt.md
+++ b/ralph/architecture-prompt.md
@@ -8,6 +8,19 @@ You are an AI software architect. Your job is to analyze the research findings f
 - `ralph/screenshots/inspect/`: Visual evidence from the original product.
 - `ralph-config.json`: The core stack and provider preferences.
 
+## Required Reads Before Deciding
+
+The loop prompt provides context as a manifest to keep long runs under budget. Do not infer the contents of those files from their names.
+
+Before producing any architecture decision, read these files with `cat` or your Read tool:
+- `ralph-config.json` first — confirms language, stackProfile, cloudProvider, authMode, frontend, deployment tier, and services.
+- `BUILD_GUIDE.md` — authoritative stack layout, runtime commands, ports, database layer, and deployment assumptions.
+- `prd.json` — actual feature inventory, priorities, categories, dependencies, and required backend behavior.
+- `target-docs/INDEX.md` — documentation inventory; then open only the specific API, SDK, auth, webhook, or infrastructure docs needed for the decisions.
+- `schemas/architecture-decision.schema.json` — required JSON output shape.
+
+Inspect `ralph/screenshots/inspect/` before component-structure or layout decisions. Do not write `ralph/architecture-decisions.json` or `build-spec.md` from memory alone.
+
 ## Your Goal
 Bridge the gap between "what exists" (PRD) and "how to build it" (Architecture).
 You must produce a set of concrete **Architecture Decisions**.

--- a/ralph/build-prompt.md
+++ b/ralph/build-prompt.md
@@ -25,6 +25,19 @@ Rules:
 - `ralph/screenshots/build/`: Your own verification screenshots (save yours here).
 - `target-docs/`: Extracted docs — API reference, guides, SDK examples.
 
+## Required Reads Before Acting
+
+The loop prompt provides context as a manifest to keep long runs under budget. Do not infer the contents of those files from their names.
+
+Before choosing or changing a feature, read these files with `cat` or your Read tool:
+- `build-spec.md` first — primary architecture, design, data model, and build-order source.
+- `build-progress.txt` — prior implementation decisions and test results.
+- `prd.json` — pick the first `build_pass: false` entry and inspect its `ui_details`, `behavior`, `data_model`, and dependencies.
+- `ralph-config.json`, `BUILD_GUIDE.md`, and `.ralph-setup-done` — confirm stack, commands, auth mode, provider, and file layout.
+- `CLAUDE.md` — repo-specific quality and command expectations.
+
+Read `qa-report.json` before any rebuild-mode fix. Read `target-docs/INDEX.md` before implementing API, SDK, auth, webhook, infrastructure, or deployment behavior from docs. Inspect screenshots before UI work.
+
 ## This Iteration
 
 1. Read `build-spec.md` for the overall architecture and build order.

--- a/ralph/build-ralph.sh
+++ b/ralph/build-ralph.sh
@@ -160,7 +160,20 @@ for ((i=1; i<=$ITERATIONS; i++)); do
     echo "  → Rebuild mode: QA failures detected, providing root-cause context"
 
     result=$(agent_invoke 1200 \
-"@ralph/build-prompt.md @ralph/pre-setup.md @build-spec.md @prd.json @build-progress.txt @CLAUDE.md @ralph-config.json @qa-report.json
+"@ralph/build-prompt.md
+
+== CONTEXT FILES (read with cat / your Read tool before using their contents) ==
+  - build-spec.md        — primary product, architecture, design, data, and build-order spec
+  - prd.json             — feature list; pick the first build_pass:false entry
+  - build-progress.txt   — work already completed; read before choosing implementation work
+  - qa-report.json       — QA failures for rebuild mode; inspect before patching
+  - CLAUDE.md            — repo commands, stack notes, and quality standards
+  - ralph/pre-setup.md   — environment and tooling notes
+  - ralph-config.json    — stack, provider, auth, browser, and deployment config
+  - BUILD_GUIDE.md       — stack-specific commands and layout after onboarding
+  - target-docs/INDEX.md — scraped documentation index for API/SDK behavior
+  - ralph/screenshots/inspect/ — original product visual references
+  - ralph/screenshots/build/   — save build smoke-test screenshots here
 
 ITERATION: $i of $ITERATIONS
 PROGRESS: $PASSES/$TOTAL features build_pass
@@ -193,7 +206,19 @@ Output <promise>COMPLETE</promise> only if ALL features pass.")
   else
     # FRESH BUILD MODE: No QA failures — standard build prompt
     result=$(agent_invoke 1200 \
-"@ralph/build-prompt.md @ralph/pre-setup.md @build-spec.md @prd.json @build-progress.txt @CLAUDE.md @ralph-config.json
+"@ralph/build-prompt.md
+
+== CONTEXT FILES (read with cat / your Read tool before using their contents) ==
+  - build-spec.md        — primary product, architecture, design, data, and build-order spec
+  - prd.json             — feature list; pick the first build_pass:false entry
+  - build-progress.txt   — work already completed; read before choosing implementation work
+  - CLAUDE.md            — repo commands, stack notes, and quality standards
+  - ralph/pre-setup.md   — environment and tooling notes
+  - ralph-config.json    — stack, provider, auth, browser, and deployment config
+  - BUILD_GUIDE.md       — stack-specific commands and layout after onboarding
+  - target-docs/INDEX.md — scraped documentation index for API/SDK behavior
+  - ralph/screenshots/inspect/ — original product visual references
+  - ralph/screenshots/build/   — save build smoke-test screenshots here
 
 ITERATION: $i of $ITERATIONS
 PROGRESS: $PASSES/$TOTAL features build_pass

--- a/ralph/inspect-prompt.md
+++ b/ralph/inspect-prompt.md
@@ -24,6 +24,19 @@ This is a **generic product cloning system** — the target could be any SaaS st
 - `inspect-progress.txt`: What you've already inspected (read first, update at end).
 - `target-docs/`: **Pre-scraped target product documentation.** A deterministic Python scraper (`scripts/scrape-docs.py`) populated this directory before iteration 1. Read `target-docs/INDEX.md` first to see what's available. **You do NOT need to scrape docs yourself** — read from disk.
 
+## Required Reads Before Acting
+
+The loop prompt provides context as a manifest to keep long runs under budget. Do not infer the contents of those files from their names.
+
+Before choosing work for an iteration, read these files with `cat` or your Read tool:
+- `inspect-progress.txt` first — tells you what was already inspected.
+- `ralph/inspect-spec.md` — authoritative inspection strategy and required artifacts.
+- `ralph-config.json` — confirms browser agent, stack, auth, provider, and deployment choices.
+- `BUILD_GUIDE.md` and `.ralph-setup-done` after onboarding — authoritative stack layout and commands.
+- `target-docs/INDEX.md` and `target-docs/coverage.json` before using docs evidence.
+
+Read `ralph/ever-cli-reference.md` before using Ever-specific commands. Read `prd.json` before appending or updating feature entries.
+
 ## This Iteration
 
 1. Read `inspect-progress.txt` to see what has been done.

--- a/ralph/inspect-ralph.sh
+++ b/ralph/inspect-ralph.sh
@@ -147,13 +147,23 @@ echo ""
 for ((i=1; i<=$ITERATIONS; i++)); do
   echo "--- Inspection iteration $i/$ITERATIONS ---"
 
-  _BROWSER_REF=""
-  [ "$BROWSER_AGENT" = "ever" ] && _BROWSER_REF="@ralph/ever-cli-reference.md"
   result=$(agent_invoke 1200 \
-"@ralph/inspect-prompt.md @ralph/inspect-spec.md $_BROWSER_REF @prd.json @inspect-progress.txt @ralph/pre-setup.md @ralph-config.json
+"@ralph/inspect-prompt.md
+
+== CONTEXT FILES (read with cat / your Read tool only when needed) ==
+  - ralph/inspect-spec.md       — full inspection strategy and output requirements
+  - prd.json                    — feature list to append/update
+  - inspect-progress.txt        — inspected pages and current progress; read first
+  - ralph/pre-setup.md          — environment and tooling notes
+  - ralph-config.json           — stack, provider, auth, browser, and deployment config
+  - BUILD_GUIDE.md              — stack-specific commands and layout after onboarding
+  - target-docs/INDEX.md        — scraped documentation index; open before raw docs
+  - target-docs/coverage.json   — scraper coverage result and discovery method
+  - ralph/ever-cli-reference.md — Ever CLI reference when browserAgent is ever
 
 TARGET URL: $TARGET_URL
 ITERATION: $i of $ITERATIONS
+BROWSER_AGENT: $BROWSER_AGENT
 
 Inspect exactly ONE page/feature, then commit, push, and stop.
 Output <promise>NEXT</promise> when done with this page.

--- a/ralph/ralph-watchdog.sh
+++ b/ralph/ralph-watchdog.sh
@@ -613,7 +613,15 @@ if inspect_done && ! architecture_done; then
   # pipefail-safe pattern inline rather than passing it to run_phase (which
   # execs an external command).
   set +e +o pipefail
-  agent_invoke 1800 "@ralph/architecture-prompt.md @prd.json @target-docs/INDEX.md @ralph-config.json" \
+  agent_invoke 1800 "@ralph/architecture-prompt.md
+
+== CONTEXT FILES (read with cat / your Read tool before making decisions) ==
+  - prd.json                    — discovered feature inventory and priorities
+  - ralph-config.json           — stack, provider, auth, browser, and deployment config
+  - BUILD_GUIDE.md              — stack-specific commands, layout, and deployment assumptions
+  - target-docs/INDEX.md        — scraped documentation index; open specific docs as needed
+  - ralph/screenshots/inspect/  — visual evidence from inspection
+  - schemas/architecture-decision.schema.json — required architecture decision shape" \
     2>&1 | tee -a "$LOG_FILE" > "$PHASE_LOG_TMP"
   ARCHITECTURE_EXIT=${PIPESTATUS[0]}
   set -e -o pipefail

--- a/tests/lazy-context-manifest.test.ts
+++ b/tests/lazy-context-manifest.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const read = (relativePath: string) =>
+	fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+describe("lazy context manifests", () => {
+	it("keeps inspect and build loop context files as manifest paths instead of eager @file references", () => {
+		const inspect = read("ralph/inspect-ralph.sh");
+		const build = read("ralph/build-ralph.sh");
+
+		for (const content of [inspect, build]) {
+			expect(content).toContain("== CONTEXT FILES");
+		}
+
+		expect(inspect).toContain("@ralph/inspect-prompt.md");
+		expect(inspect).not.toContain("@ralph/inspect-spec.md");
+		expect(inspect).not.toContain("@prd.json");
+		expect(inspect).not.toContain("@inspect-progress.txt");
+		expect(inspect).not.toContain("@ralph/pre-setup.md");
+		expect(inspect).not.toContain("@ralph-config.json");
+		expect(inspect).not.toContain("@ralph/ever-cli-reference.md");
+
+		expect(build).toContain("@ralph/build-prompt.md");
+		expect(build).not.toContain("@ralph/pre-setup.md");
+		expect(build).not.toContain("@build-spec.md");
+		expect(build).not.toContain("@prd.json");
+		expect(build).not.toContain("@build-progress.txt");
+		expect(build).not.toContain("@CLAUDE.md");
+		expect(build).not.toContain("@ralph-config.json");
+		expect(build).not.toContain("@qa-report.json");
+	});
+
+	it("keeps architecture context files as manifest paths instead of eager @file references", () => {
+		const watchdog = read("ralph/ralph-watchdog.sh");
+
+		expect(watchdog).toContain("@ralph/architecture-prompt.md");
+		expect(watchdog).toContain("== CONTEXT FILES");
+		expect(watchdog).not.toContain("@prd.json");
+		expect(watchdog).not.toContain("@target-docs/INDEX.md");
+		expect(watchdog).not.toContain("@ralph-config.json");
+	});
+
+	it("tells agents which manifest files must be read before acting", () => {
+		expect(read("ralph/inspect-prompt.md")).toContain(
+			"## Required Reads Before Acting",
+		);
+		expect(read("ralph/build-prompt.md")).toContain(
+			"## Required Reads Before Acting",
+		);
+		expect(read("ralph/architecture-prompt.md")).toContain(
+			"## Required Reads Before Deciding",
+		);
+	});
+});

--- a/tests/ralph-watchdog-verification.test.ts
+++ b/tests/ralph-watchdog-verification.test.ts
@@ -17,7 +17,7 @@ describe("ralph-watchdog verification gate", () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "watchdog-test-"));
-    fs.mkdirSync(path.join(tmpDir, "ralph"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "ralph/lib"), { recursive: true });
 
     execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
     execFileSync("git", ["config", "user.name", "Test User"], {
@@ -33,10 +33,18 @@ describe("ralph-watchdog verification gate", () => {
       path.join(repoRoot, "ralph/ralph-watchdog.sh"),
       path.join(tmpDir, "ralph/ralph-watchdog.sh"),
     );
+    fs.copyFileSync(
+      path.join(repoRoot, "ralph/lib/agent-runner.sh"),
+      path.join(tmpDir, "ralph/lib/agent-runner.sh"),
+    );
 
     fs.writeFileSync(
       path.join(tmpDir, "ralph-config.json"),
       JSON.stringify({ browserAgent: "none" }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "ralph/architecture-decisions.json"),
+      "[]",
     );
 
     fs.writeFileSync(


### PR DESCRIPTION
## What
- Changes inspect, build, and architecture loop invocations to inline only the master prompt plus a lazy context-file manifest.
- Adds explicit required-read sections to the master prompts so agents open the right files before acting instead of guessing from filenames.
- Adds regression coverage that blocks reintroducing eager `@file` context references for the per-iteration loops.
- Fixes the watchdog test fixture so it copies `ralph/lib/agent-runner.sh` and stays hermetic instead of invoking a real architecture agent.

## Why
Long Ralph runs call these loops repeatedly. Eagerly attaching every context file burns tokens before the agent starts useful work, which keeps the system closer to hackathon MVP behavior than production-grade long-run economics. This implements the issue #67 manifest pattern while preserving the master prompt inline contract.

## Verification
- `npx vitest run --testTimeout=20000`
- `npx vitest run tests/lazy-context-manifest.test.ts --testTimeout=10000`
- `sh -n ralph/inspect-ralph.sh && sh -n ralph/build-ralph.sh && sh -n ralph/ralph-watchdog.sh && sh -n ralph/lib/agent-runner.sh && git diff --check`

## Known gaps
- `make check` / `make test` do not run in this pipeline checkout because the Makefile intentionally stops without `.ralph-setup-done`.
- `python3 -m unittest tests/test_scrape_docs_pipeline.py` does not run in the local Python 3.14 environment because `requests` is not installed.

Closes #67