### PR TITLE
Keep scrape-docs regression test hermetic

### DIFF
--- a/tests/test_scrape_docs_pipeline.py
+++ b/tests/test_scrape_docs_pipeline.py
@@ -50,6 +50,11 @@ def _stub_heavy_imports() -> None:
         sys.modules["defusedxml"] = defusedxml
         sys.modules["defusedxml.ElementTree"] = et
 
+    if "requests" not in sys.modules:
+        requests = types.ModuleType("requests")
+        requests.get = lambda *a, **k: None  # type: ignore
+        sys.modules["requests"] = requests
+
 
 _stub_heavy_imports()
 


### PR DESCRIPTION
## What
- Stubs `requests` in `tests/test_scrape_docs_pipeline.py` alongside the other scraper import-time dependencies.
- Restores the test contract documented in the file: it can run under bare `python3` without `.venv-scrape` or scraper requirements installed.

## Why
Production hardening depends on tests proving behavior, not accidentally proving that one developer machine has a dependency installed globally. This keeps the discovery-ladder regression focused on scraper logic and makes local/CI validation less fragile.

## Verification
- `python3 -m unittest tests/test_scrape_docs_pipeline.py`
- `git diff --check`

## Known gaps
- This is deterministic unit coverage only; it does not exercise live network scraping.